### PR TITLE
Add 'cargo publish' mandatory information

### DIFF
--- a/mla/Cargo.toml
+++ b/mla/Cargo.toml
@@ -3,6 +3,11 @@ name = "mla"
 version = "1.0.0"
 authors = ["Camille Mougey <camille.mougey@ssi.gouv.fr>"]
 edition = "2018"
+license = "LGPL-3.0-only"
+description = "Multi Layer Archive - A pure rust encrypted and compressed archive file format"
+homepage = "https://github.com/ANSSI-FR/MLA"
+repository = "https://github.com/ANSSI-FR/MLA"
+readme = "../README.md"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
For now, information are only available for `mla`

For the others packages, another PR will follow in the next days