### PR TITLE
Keep CI artifacts

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -13,10 +13,16 @@ jobs:
   build:
     strategy:
       matrix:
-        os:
-          - ubuntu-latest
-          - windows-latest
-          - macos-latest
+        build: [linux, macos, windows]
+        include:
+          - build: linux
+            os: ubuntu-latest
+          - build: macos
+            os: macos-latest
+          - build: windows
+            os: windows-latest
+            extension: .exe
+
     runs-on: ${{matrix.os}}
 
     steps:
@@ -31,6 +37,11 @@ jobs:
         args: --release --all-features --all --exclude mla-fuzz-afl --verbose
     - name: Run tests
       run: cargo test --all --exclude mla-fuzz-afl --release --verbose
+    - name: Upload resulting 'mlar'
+      uses: actions/upload-artifact@v1
+      with:
+        name: ${{ matrix.build }}
+        path: ./target/release/mlar${{ matrix.extension }}
 
   afl-build:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Rust
+name: Build & test
 
 on:
   push:


### PR DESCRIPTION
This PR:
* back-up `mlar` results of linux, macos and windows builds for easier day-to-day debugging / nightly release
* rename the workflow from "Rust" to "Build & test", reflecting its purpose