### PR TITLE
Create a release for 'mlar' on mlar-v* tags

### DIFF
--- a/.github/workflows/mlar_release.yml
+++ b/.github/workflows/mlar_release.yml
@@ -1,0 +1,116 @@
+name: mlar release
+
+on:
+  push:
+    tags:
+      - "mlar-v*"
+
+env:
+  GITHUB_REF: "${{ github.ref }}"
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        build: [linux, macos, windows]
+        include:
+          - build: linux
+            os: ubuntu-latest
+            target: x86_64-unknown-linux-musl
+            cargo_build: --target x86_64-unknown-linux-musl
+          - build: macos
+            os: macos-latest
+          - build: windows
+            os: windows-latest
+            extension: .exe
+
+    runs-on: ${{matrix.os}}
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+    - name: Set target if any
+      if: matrix.target
+      run: rustup target add ${{ matrix.target }}
+    - name: Build
+      uses: actions-rs/cargo@v1
+      with:
+        command: build
+        args: --release --all-features --package mlar --verbose ${{ matrix.cargo_build }}
+    - name: Strip resulting binary
+      if: matrix.build == 'linux'
+      run: strip ./target/${{ matrix.target }}/release/mlar${{ matrix.extension }}
+    - name: Upload resulting 'mlar'
+      uses: actions/upload-artifact@v1
+      with:
+        name: mlar-${{ matrix.build }}
+        path: ./target/${{ matrix.target }}/release/mlar${{ matrix.extension }}
+
+  release:
+    # From https://github.com/cloudflare/wrangler/blob/master/.github/workflows/release.yml
+    name: GitHub Release
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Query version number
+        id: get_version
+        shell: bash
+        run: |
+          echo "using version tag ${GITHUB_REF:15}"
+          echo ::set-output name=version::"${GITHUB_REF:15}"
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: mlar-${{ steps.get_version.outputs.VERSION }}
+          release_name: mlar-${{ steps.get_version.outputs.VERSION }}
+          draft: true
+
+      - name: Download Linux artifact
+        uses: actions/download-artifact@v1
+        with:
+          name: mlar-linux
+
+      - name: Download Windows artifact
+        uses: actions/download-artifact@v1
+        with:
+          name: mlar-windows
+
+      - name: Download MacOS artifact
+        uses: actions/download-artifact@v1
+        with:
+          name: mlar-macos
+
+      - name: Release Linux artifact
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./mlar-linux/mlar
+          asset_content_type: application/octet-stream
+          asset_name: mlar-linux-static-${{ steps.get_version.outputs.VERSION }}
+
+      - name: Release Windows artifact
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./mlar-windows/mlar.exe
+          asset_content_type: application/octet-stream
+          asset_name: mlar-windows-${{ steps.get_version.outputs.VERSION }}
+
+      - name: Release MacOS artifact
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./mlar-macos/mlar
+          asset_content_type: application/octet-stream
+          asset_name: mlar-macos-${{ steps.get_version.outputs.VERSION }}


### PR DESCRIPTION
Tested on a fork repository (https://github.com/commial/MLA/runs/913969421)

On `mlar-vA.B.C` tag:

1. Create a release for `mlar` vA.B.C
1. Compile in release mode:
  - Linux (static 64 bits), stripped
  - MacOS
  - Windows
3. Add the resulting binaries to the release 