### PR TITLE
CI: add a Dependabot (Github owned) dependency checker

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+- package-ecosystem: cargo
+  directory: "/"
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 10


### PR DESCRIPTION
For more information, the related Github blog post: https://github.blog/2020-06-01-keep-all-your-packages-up-to-date-with-dependabot/