### PR TITLE
Add support for '-' output in 'mlar to-tar'

### DIFF
--- a/mlar/src/main.rs
+++ b/mlar/src/main.rs
@@ -600,8 +600,8 @@ fn to_tar(matches: &ArgMatches) -> Result<(), Error> {
 
     // Safe to use unwrap() because the option is required()
     let output = matches.value_of("output").unwrap();
-    let path = Path::new(&output);
-    let mut tar_file = Builder::new(File::create(&path)?);
+    let destination = destination_from_output_argument(output)?;
+    let mut tar_file = Builder::new(destination);
 
     let iter = mla.list_files()?;
     let fnames: Vec<String> = iter.cloned().collect();


### PR DESCRIPTION
Use `destination_from_output_argument` to allow `mlar to-tar` to produce the tar file on `stdout`.
Unlike `mlar cat`, output argument is still required since it make no sense to produce binary data to `stdout` by default.