### PR TITLE
Force aes and aes-ctr to 0.5, to avoid compilation issue with the last available

### DIFF
--- a/curve25519-parser/src/lib.rs
+++ b/curve25519-parser/src/lib.rs
@@ -18,8 +18,8 @@ use rand_core::{CryptoRng, RngCore};
 
 use std::fmt;
 
-const ED_25519_OID: Oid<'static> = oid!(1.3.101.112);
-const X_25519_OID: Oid<'static> = oid!(1.3.101.110);
+const ED_25519_OID: Oid<'static> = oid!(1.3.101 .112);
+const X_25519_OID: Oid<'static> = oid!(1.3.101 .110);
 
 // ---- Error handling ----
 

--- a/mla/Cargo.toml
+++ b/mla/Cargo.toml
@@ -15,7 +15,7 @@ readme = "../README.md"
 rand = "0.7"
 rand_chacha = "0.2"
 brotli = "3.3"
-aes-ctr = "0"
+aes-ctr = "0.5"
 bitflags = "1.2"
 byteorder = "1.3"
 serde = { version = "1", features = ["derive"] }
@@ -24,7 +24,7 @@ bincode = "~1.2"
 # Version fixed due to avoid conflict dependencies with `aes`, `aes-ctr` and `ghash`
 generic-array = "0.14"
 ghash = "0"
-aes = "0"
+aes = "0.5"
 subtle = "2"
 digest = "0"
 # ECC


### PR DESCRIPTION
Current release is running with `aes=0.5` and `aes-ctr=05`.

Starting at "0.6", the project is using a separate crate for `cipher`. To avoid bumping dependencies for now, this PR uses the last known working version.

A future version will have its dependencies updated.