### PR TITLE
Fix a u32 overflow addition in the compress layer

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,6 +45,17 @@ jobs:
         name: ${{ matrix.build }}
         path: ./target/release/mlar${{ matrix.extension }}
 
+  long-tests:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+    - name: Run long tests
+      run: cd mla && cargo test --release -- --ignored
+        
   afl-build:
     runs-on: ubuntu-latest
 

--- a/mla/src/layers/compress.rs
+++ b/mla/src/layers/compress.rs
@@ -254,8 +254,12 @@ impl<'a, R: 'a + Read> CompressionLayerReader<'a, R> {
                 compressed_sizes, ..
             }) => {
                 // Move the underlayer at the start of the block
-                let start_position: u32 = compressed_sizes.iter().take(block_num as usize).sum();
-                inner.seek(SeekFrom::Start(start_position as u64))?;
+                let start_position = compressed_sizes
+                    .iter()
+                    .take(block_num as usize)
+                    .map(|size| *size as u64)
+                    .sum();
+                inner.seek(SeekFrom::Start(start_position))?;
             }
             None => {
                 return Err(Error::MissingMetadata);

--- a/mla/src/lib.rs
+++ b/mla/src/lib.rs
@@ -2065,13 +2065,14 @@ pub(crate) mod tests {
     }
 
     #[test]
+    #[ignore]
     fn more_than_u32_file() {
         // Use a deterministic RNG in tests, for reproductability. DO NOT DO THIS IS IN ANY RELEASED BINARY!
         let mut rng = ChaChaRng::seed_from_u64(0);
         let mut rng_data = ChaChaRng::seed_from_u64(0);
 
-        const MAX_SIZE: u64 = 6 * 1024 * 1024 * 1024; // 6 GB
         const MORE_THAN_U32: u64 = 0x100010000; // U32_max + 0x10000
+        const MAX_SIZE: u64 = 5 * 1024 * 1024 * 1024; // 5 GB
         const CHUNK_SIZE: usize = 10 * 1024 * 1024; // 10 MB
 
         let key = StaticSecret::new(&mut rng);


### PR DESCRIPTION
Should fixes #63

Add a test with files bigger than 32bits to reach certain code paths.
As a result, tests are longer and needs more RAM.