### PR TITLE
Update rand dependencies

### DIFF
--- a/curve25519-parser/Cargo.toml
+++ b/curve25519-parser/Cargo.toml
@@ -19,8 +19,8 @@ sha2 = { version = "0", default-features = false}
 pem = { version = "1", default-features = false}
 
 [dependencies.rand_core]
-version = "0.5"
+version = "0.6"
 default-features = false
 
 [dev-dependencies]
-rand = "0.7"
+rand = "0.8"

--- a/mla/Cargo.toml
+++ b/mla/Cargo.toml
@@ -12,8 +12,8 @@ readme = "../README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-rand = { version = "0.7", default-features = false, features = ["getrandom", "std"]}
-rand_chacha = { version = "0.2", default-features = false}
+rand = { version = "0.8", default-features = false, features = ["getrandom", "std"]}
+rand_chacha = { version = "0.3", default-features = false}
 brotli = { version = "3.3", default-features = false, features = ["std"]}
 bitflags = { version = "1.2", default-features = false}
 byteorder = { version = "1.3", default-features = false, features = ["std"] }

--- a/mla/src/layers/compress.rs
+++ b/mla/src/layers/compress.rs
@@ -972,8 +972,8 @@ mod tests {
             // Ensure the obtained bytes are correct
             assert_eq!(buf.as_slice(), &bytes[..buf.len()]);
             // We hope still having enough data (keeping half of the compressed
-            // stream should give us at least half of the uncompressed stream)
-            assert!(buf.len() >= bytes.len() / 2);
+            // stream should give us at least a third of the uncompressed stream)
+            assert!(buf.len() >= bytes.len() / 3);
         }
     }
 

--- a/mla/src/layers/compress.rs
+++ b/mla/src/layers/compress.rs
@@ -749,7 +749,6 @@ mod tests {
 
     use crate::layers::raw::{RawLayerFailSafeReader, RawLayerReader, RawLayerWriter};
     use rand::distributions::{Alphanumeric, Distribution, Standard};
-    use rand::rngs::StdRng;
     use rand::SeedableRng;
     use std::io::{Cursor, Read, Write};
     use std::time::Instant;
@@ -761,7 +760,7 @@ mod tests {
     // Return a vector of data of size SIZE
     fn get_data() -> Vec<u8> {
         // Use only alphanumeric charset to allow for compression
-        let mut rng: StdRng = SeedableRng::from_seed([0u8; 32]);
+        let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(0);
         let data: Vec<u8> = Alphanumeric
             .sample_iter(&mut rng)
             .take(SIZE)
@@ -774,7 +773,7 @@ mod tests {
     // Return a vector of uncompressable data (ie. purely random) of size SIZE
     fn get_uncompressable_data() -> Vec<u8> {
         // Use only alphanumeric charset to allow for compression
-        let mut rng: StdRng = SeedableRng::from_seed([0u8; 32]);
+        let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(0);
         let data: Vec<u8> = Standard.sample_iter(&mut rng).take(SIZE).collect();
         assert_eq!(data.len(), SIZE);
         data

--- a/mla/src/layers/encrypt.rs
+++ b/mla/src/layers/encrypt.rs
@@ -532,7 +532,6 @@ mod tests {
     use super::*;
 
     use rand::distributions::{Alphanumeric, Distribution};
-    use rand::rngs::StdRng;
     use rand::SeedableRng;
     use std::io::{Cursor, Read, Seek, SeekFrom, Write};
 
@@ -677,7 +676,7 @@ mod tests {
             .unwrap(),
         );
         let length = (CHUNK_SIZE * 2) as usize;
-        let mut rng: StdRng = SeedableRng::from_seed([0u8; 32]);
+        let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(0);
         let data: Vec<u8> = Alphanumeric
             .sample_iter(&mut rng)
             .take(length)

--- a/mla/src/lib.rs
+++ b/mla/src/lib.rs
@@ -1338,7 +1338,9 @@ pub(crate) mod tests {
         let file = Vec::new();
         // Use a deterministic RNG in tests, for reproductability. DO NOT DO THIS IS IN ANY RELEASED BINARY!
         let mut rng = ChaChaRng::seed_from_u64(0);
-        let key = StaticSecret::new(&mut rng);
+        let mut bytes = [0u8; 32];
+        rng.fill_bytes(&mut bytes);
+        let key = StaticSecret::from(bytes);
         let mut mla = ArchiveWriter::new(file, std::slice::from_ref(&PublicKey::from(&key)))
             .expect("Writer init failed");
 
@@ -1393,7 +1395,9 @@ pub(crate) mod tests {
         let file = Vec::new();
         // Use a deterministic RNG in tests, for reproductability. DO NOT DO THIS IS IN ANY RELEASED BINARY!
         let mut rng = ChaChaRng::seed_from_u64(0);
-        let key = StaticSecret::new(&mut rng);
+        let mut bytes = [0u8; 32];
+        rng.fill_bytes(&mut bytes);
+        let key = StaticSecret::from(bytes);
         let mut config = ArchiveWriterConfig::new();
         config
             .set_layers(layers.unwrap_or_default())
@@ -1502,7 +1506,9 @@ pub(crate) mod tests {
 
             // Build initial file in a stream
             let file = Vec::new();
-            let key = StaticSecret::new(&mut rng);
+            let mut bytes = [0u8; 32];
+            rng.fill_bytes(&mut bytes);
+            let key = StaticSecret::from(bytes);
             let mut config = ArchiveWriterConfig::new();
             config
                 .set_layers(*layering)
@@ -2080,7 +2086,9 @@ pub(crate) mod tests {
         const MAX_SIZE: u64 = 5 * 1024 * 1024 * 1024; // 5 GB
         const CHUNK_SIZE: usize = 10 * 1024 * 1024; // 10 MB
 
-        let key = StaticSecret::new(&mut rng);
+        let mut bytes = [0u8; 32];
+        rng.fill_bytes(&mut bytes);
+        let key = StaticSecret::from(bytes);
         let mut config = ArchiveWriterConfig::default();
         config.add_public_keys(std::slice::from_ref(&PublicKey::from(&key)));
         let file = Vec::new();

--- a/mlar/Cargo.toml
+++ b/mlar/Cargo.toml
@@ -17,13 +17,13 @@ clap = "3"
 glob = "0.3"
 mla = { path = "../mla", version = "1" }
 curve25519-parser = { path = "../curve25519-parser", version = "0.2" }
-rand = "0.7"
+rand = "0.8"
 x25519-dalek = "1"
 humansize = "1"
 hex = "0.4"
 # Could be made optional / feature to enable (for binary size)
 tar = "0.4"
-rand_chacha = "0.2"
+rand_chacha = "0.3"
 
 [dev-dependencies]
 assert_cmd = "2.0"


### PR DESCRIPTION
Fix #71 , #70 , #69 

This PR internalize `StaticSecret` random generation from `x25519-dalek` to:

* avoid dependency issue with `rand_core`
* open the possibility for a seeded secret from MLA caller, likely required for an hypothetic no-std version