### PR TITLE
Add a feature "send" to provide an Send ArchiveWriter

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,7 @@ jobs:
       uses: actions-rs/cargo@v1
       with:
         command: build
-        args: --release --all-features --all --exclude mla-fuzz-afl --verbose
+        args: --release --all --exclude mla-fuzz-afl --verbose
     - name: Run tests
       run: cargo test --all --exclude mla-fuzz-afl --release --verbose
     - name: Upload resulting 'mlar'
@@ -55,6 +55,17 @@ jobs:
         toolchain: stable
     - name: Run long tests
       run: cd mla && cargo test --release -- --ignored
+
+  all-features:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+    - name: Run long tests
+      run: cargo test --all-features --all --exclude mla-fuzz-afl --exclude mla-bindings-c --release
 
   test-bindings-c-cpp-linux:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -475,3 +475,15 @@ If you have found crashes, try to replay them with either:
 * Debugging: uncomment the "Replay sample" part of `mla-fuzz-afl/src/main.rs`, and add `dbg!()` when it's needed
 
 :warning: The stability is quite low, likely due to the process used for the scenario (deserialization from the data provided by AFL) and variability of inner algorithms, such as brotli. Crashes, if any, might not be reproducible or due to the `mla-fuzz-afl` inner working, which is a bit complex (and therefore likely buggy). One can comment unrelevant parts in `mla-fuzz-afl/src/main.rs` to ensure a better experience.
+
+FAQ
+-
+
+**Is `MLAArchiveWriter` `Send`?**
+
+By default, `MLAArchiveWriter` is not `Send`. If the inner writable type is also `Send`, one can enable the feature `send` for `mla` in `Cargo.toml`, such as:
+
+```toml
+[dependencies]
+mla = { version = "...", default-features = false, features = ["send"]}
+```

--- a/mla/Cargo.toml
+++ b/mla/Cargo.toml
@@ -40,6 +40,10 @@ aead = { version = "0.4", default-features = false, features = ["alloc"]}
 criterion = { version = "0.3", default-features = false}
 curve25519-parser = { path = "../curve25519-parser" }
 hex = { version = "0.4", default-features = false, features = ["alloc"]}
+static_assertions = { version = "1", default-features = false }
+
+[features]
+send = []
 
 [[bench]]
 name = "bench_archive"

--- a/mla/src/helpers.rs
+++ b/mla/src/helpers.rs
@@ -1,3 +1,4 @@
+use super::layers::traits::InnerWriterTrait;
 /// Helpers for common operation with MLA Archives
 use super::{ArchiveFileBlock, ArchiveFileID, ArchiveReader, ArchiveWriter, Error};
 use std::collections::HashMap;
@@ -18,7 +19,7 @@ use std::io::{self, Read, Seek, SeekFrom, Write};
 /// encryption tag).
 /// Linear extraction avoids these costs by reading once and only once each byte,
 /// and by reducing the amount of seeks.
-pub fn linear_extract<W1: Write, R: Read + Seek, S: BuildHasher>(
+pub fn linear_extract<W1: InnerWriterTrait, R: Read + Seek, S: BuildHasher>(
     archive: &mut ArchiveReader<R>,
     export: &mut HashMap<&String, W1, S>,
 ) -> Result<(), Error> {
@@ -77,18 +78,18 @@ pub fn linear_extract<W1: Write, R: Read + Seek, S: BuildHasher>(
 /// This interface is meant to be used in situations where length of the data
 /// source is unknown, such as a stream. One can then use the `io::copy`
 /// facilities to perform multiples block addition in the archive
-pub struct StreamWriter<'a, 'b, W: Write> {
+pub struct StreamWriter<'a, 'b, W: InnerWriterTrait> {
     archive: &'b mut ArchiveWriter<'a, W>,
     file_id: ArchiveFileID,
 }
 
-impl<'a, 'b, W: Write> StreamWriter<'a, 'b, W> {
+impl<'a, 'b, W: InnerWriterTrait> StreamWriter<'a, 'b, W> {
     pub fn new(archive: &'b mut ArchiveWriter<'a, W>, file_id: ArchiveFileID) -> Self {
         Self { archive, file_id }
     }
 }
 
-impl<'a, 'b, W: Write> Write for StreamWriter<'a, 'b, W> {
+impl<'a, 'b, W: InnerWriterTrait> Write for StreamWriter<'a, 'b, W> {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         self.archive
             .append_file_content(self.file_id, buf.len() as u64, buf)?;

--- a/mla/src/layers/encrypt.rs
+++ b/mla/src/layers/encrypt.rs
@@ -1,7 +1,7 @@
 use crate::crypto::aesgcm::{AesGcm256, ConstantTimeEq, Key, Nonce, Tag, TAG_LENGTH};
 use crate::crypto::ecc::{retrieve_key, store_key_for_multi_recipients, MultiRecipientPersistent};
 
-use crate::layers::traits::{LayerFailSafeReader, LayerReader, LayerWriter};
+use crate::layers::traits::{LayerFailSafeReader, LayerReader, LayerWriter, InnerWriterType};
 use crate::Error;
 use std::io;
 use std::io::{BufReader, Cursor, Read, Seek, SeekFrom, Write};
@@ -178,7 +178,7 @@ impl ArchiveReaderConfig {
 // ---------- Writer ----------
 
 pub struct EncryptionLayerWriter<'a, W: 'a + Write> {
-    inner: Box<dyn 'a + LayerWriter<'a, W>>,
+    inner: InnerWriterType<'a, W>,
     cipher: AesGcm256,
     /// Symmetric encryption Key
     key: Key,
@@ -190,7 +190,7 @@ pub struct EncryptionLayerWriter<'a, W: 'a + Write> {
 
 impl<'a, W: 'a + Write> EncryptionLayerWriter<'a, W> {
     pub fn new(
-        inner: Box<dyn 'a + LayerWriter<'a, W>>,
+        inner: InnerWriterType<'a, W>,
         config: &EncryptionConfig,
     ) -> Result<Self, Error> {
         Ok(Self {
@@ -218,7 +218,7 @@ impl<'a, W: 'a + Write> EncryptionLayerWriter<'a, W> {
 }
 
 impl<'a, W: 'a + Write> LayerWriter<'a, W> for EncryptionLayerWriter<'a, W> {
-    fn into_inner(self) -> Option<Box<dyn 'a + LayerWriter<'a, W>>> {
+    fn into_inner(self) -> Option<InnerWriterType<'a, W>> {
         Some(self.inner)
     }
 

--- a/mla/src/layers/position.rs
+++ b/mla/src/layers/position.rs
@@ -1,18 +1,18 @@
 use std::io;
 use std::io::Write;
 
-use crate::layers::traits::{LayerWriter, InnerWriterType};
+use crate::layers::traits::{InnerWriterTrait, InnerWriterType, LayerWriter};
 use crate::Error;
 
 // ---------- Writer ----------
 
 /// Layer used to track how many bytes have been written
-pub struct PositionLayerWriter<'a, W: 'a + Write> {
+pub struct PositionLayerWriter<'a, W: 'a + InnerWriterTrait> {
     inner: InnerWriterType<'a, W>,
     pos: u64,
 }
 
-impl<'a, W: 'a + Write> PositionLayerWriter<'a, W> {
+impl<'a, W: 'a + InnerWriterTrait> PositionLayerWriter<'a, W> {
     pub fn new(inner: InnerWriterType<'a, W>) -> Self {
         Self { inner, pos: 0 }
     }
@@ -30,7 +30,7 @@ impl<'a, W: 'a + Write> PositionLayerWriter<'a, W> {
     }
 }
 
-impl<'a, W: 'a + Write> LayerWriter<'a, W> for PositionLayerWriter<'a, W> {
+impl<'a, W: 'a + InnerWriterTrait> LayerWriter<'a, W> for PositionLayerWriter<'a, W> {
     fn into_inner(self) -> Option<InnerWriterType<'a, W>> {
         Some(self.inner)
     }
@@ -47,7 +47,7 @@ impl<'a, W: 'a + Write> LayerWriter<'a, W> for PositionLayerWriter<'a, W> {
     }
 }
 
-impl<'a, W: 'a + Write> Write for PositionLayerWriter<'a, W> {
+impl<'a, W: 'a + InnerWriterTrait> Write for PositionLayerWriter<'a, W> {
     /// Wrapper on inner
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         let written = self.inner.write(buf)?;

--- a/mla/src/layers/position.rs
+++ b/mla/src/layers/position.rs
@@ -1,19 +1,19 @@
 use std::io;
 use std::io::Write;
 
-use crate::layers::traits::LayerWriter;
+use crate::layers::traits::{LayerWriter, InnerWriterType};
 use crate::Error;
 
 // ---------- Writer ----------
 
 /// Layer used to track how many bytes have been written
 pub struct PositionLayerWriter<'a, W: 'a + Write> {
-    inner: Box<dyn 'a + LayerWriter<'a, W>>,
+    inner: InnerWriterType<'a, W>,
     pos: u64,
 }
 
 impl<'a, W: 'a + Write> PositionLayerWriter<'a, W> {
-    pub fn new(inner: Box<dyn 'a + LayerWriter<'a, W>>) -> Self {
+    pub fn new(inner: InnerWriterType<'a, W>) -> Self {
         Self { inner, pos: 0 }
     }
 
@@ -31,7 +31,7 @@ impl<'a, W: 'a + Write> PositionLayerWriter<'a, W> {
 }
 
 impl<'a, W: 'a + Write> LayerWriter<'a, W> for PositionLayerWriter<'a, W> {
-    fn into_inner(self) -> Option<Box<dyn 'a + LayerWriter<'a, W>>> {
+    fn into_inner(self) -> Option<InnerWriterType<'a, W>> {
         Some(self.inner)
     }
 

--- a/mla/src/layers/raw.rs
+++ b/mla/src/layers/raw.rs
@@ -1,7 +1,7 @@
 use std::io;
 use std::io::{Read, Seek, SeekFrom, Write};
 
-use crate::layers::traits::{LayerFailSafeReader, LayerReader, LayerWriter};
+use crate::layers::traits::{LayerFailSafeReader, LayerReader, LayerWriter, InnerWriterType};
 use crate::Error;
 
 // ---------- Writer ----------
@@ -18,7 +18,7 @@ impl<W: Write> RawLayerWriter<W> {
 }
 
 impl<'a, W: Write> LayerWriter<'a, W> for RawLayerWriter<W> {
-    fn into_inner(self) -> Option<Box<dyn 'a + LayerWriter<'a, W>>> {
+    fn into_inner(self) -> Option<InnerWriterType<'a, W>> {
         None
     }
 

--- a/mla/src/layers/raw.rs
+++ b/mla/src/layers/raw.rs
@@ -1,23 +1,25 @@
 use std::io;
 use std::io::{Read, Seek, SeekFrom, Write};
 
-use crate::layers::traits::{LayerFailSafeReader, LayerReader, LayerWriter, InnerWriterType};
+use crate::layers::traits::{
+    InnerWriterTrait, InnerWriterType, LayerFailSafeReader, LayerReader, LayerWriter,
+};
 use crate::Error;
 
 // ---------- Writer ----------
 
 /// Dummy layer, standing for the last layer (wrapping I/O)
-pub struct RawLayerWriter<W: Write> {
+pub struct RawLayerWriter<W: InnerWriterTrait> {
     inner: W,
 }
 
-impl<W: Write> RawLayerWriter<W> {
+impl<W: InnerWriterTrait> RawLayerWriter<W> {
     pub fn new(inner: W) -> Self {
         Self { inner }
     }
 }
 
-impl<'a, W: Write> LayerWriter<'a, W> for RawLayerWriter<W> {
+impl<'a, W: InnerWriterTrait> LayerWriter<'a, W> for RawLayerWriter<W> {
     fn into_inner(self) -> Option<InnerWriterType<'a, W>> {
         None
     }
@@ -32,7 +34,7 @@ impl<'a, W: Write> LayerWriter<'a, W> for RawLayerWriter<W> {
     }
 }
 
-impl<W: Write> Write for RawLayerWriter<W> {
+impl<W: InnerWriterTrait> Write for RawLayerWriter<W> {
     /// Wrapper on inner
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         self.inner.write(buf)

--- a/mla/src/layers/traits.rs
+++ b/mla/src/layers/traits.rs
@@ -3,8 +3,14 @@ use std::io::{Read, Seek, Write};
 
 /// Type alias for Layer Writer inner type
 pub type InnerWriterType<'a, W> = Box<dyn 'a + LayerWriter<'a, W>>;
+/// Trait alias for Layer Writer writable destination
+// Type aliases are not yet stable
+// See https://github.com/rust-lang/rust/issues/41517
+// -> use a dummy trait instead
+pub trait InnerWriterTrait: Write {}
+impl<T: Write> InnerWriterTrait for T {}
 /// Trait to be implemented by layer writers
-pub trait LayerWriter<'a, W: Write>: Write {
+pub trait LayerWriter<'a, W: InnerWriterTrait>: Write {
     /// Unwraps the inner writer
     fn into_inner(self) -> Option<InnerWriterType<'a, W>>;
 

--- a/mla/src/layers/traits.rs
+++ b/mla/src/layers/traits.rs
@@ -1,10 +1,12 @@
 use crate::Error;
 use std::io::{Read, Seek, Write};
 
+/// Type alias for Layer Writer inner type
+pub type InnerWriterType<'a, W> = Box<dyn 'a + LayerWriter<'a, W>>;
 /// Trait to be implemented by layer writers
 pub trait LayerWriter<'a, W: Write>: Write {
     /// Unwraps the inner writer
-    fn into_inner(self) -> Option<Box<dyn 'a + LayerWriter<'a, W>>>;
+    fn into_inner(self) -> Option<InnerWriterType<'a, W>>;
 
     /// Unwraps the original I/O writer
     // Use a Box<Self> to be able to move out the inner value; without it, self

--- a/mla/src/lib.rs
+++ b/mla/src/lib.rs
@@ -1239,6 +1239,10 @@ pub(crate) mod tests {
     use rand::distributions::{Distribution, Standard};
     use rand::{RngCore, SeedableRng};
     use rand_chacha::ChaChaRng;
+    #[cfg(feature = "send")]
+    use static_assertions;
+    #[cfg(feature = "send")]
+    use std::fs::File;
     use std::io::{Cursor, Empty, Read};
     use x25519_dalek::{PublicKey, StaticSecret};
 
@@ -2166,5 +2170,13 @@ pub(crate) mod tests {
                 }
             }
         }
+    }
+
+    #[test]
+    #[cfg(feature = "send")]
+    fn test_send() {
+        static_assertions::assert_cfg!(feature = "send");
+        static_assertions::assert_impl_all!(File: Send);
+        static_assertions::assert_impl_all!(ArchiveWriter<File>: Send);
     }
 }

--- a/mla/src/lib.rs
+++ b/mla/src/lib.rs
@@ -17,7 +17,7 @@ use crate::layers::encrypt::{
 };
 use crate::layers::position::PositionLayerWriter;
 use crate::layers::raw::{RawLayerFailSafeReader, RawLayerReader, RawLayerWriter};
-use crate::layers::traits::{LayerFailSafeReader, LayerReader, LayerWriter};
+use crate::layers::traits::{LayerFailSafeReader, LayerReader, LayerWriter, InnerWriterType};
 pub mod errors;
 use crate::errors::{Error, FailSafeReadError};
 
@@ -471,7 +471,7 @@ impl<'a, W: Write> ArchiveWriter<'a, W> {
         config.check()?;
 
         // Write archive header
-        let mut dest: Box<dyn LayerWriter<W>> = Box::new(RawLayerWriter::new(dest));
+        let mut dest: InnerWriterType<W> = Box::new(RawLayerWriter::new(dest));
         ArchiveHeader {
             format_version: MLA_FORMAT_VERSION,
             config: config.to_persistent()?,

--- a/mla/src/lib.rs
+++ b/mla/src/lib.rs
@@ -17,7 +17,9 @@ use crate::layers::encrypt::{
 };
 use crate::layers::position::PositionLayerWriter;
 use crate::layers::raw::{RawLayerFailSafeReader, RawLayerReader, RawLayerWriter};
-use crate::layers::traits::{LayerFailSafeReader, LayerReader, LayerWriter, InnerWriterType};
+use crate::layers::traits::{
+    InnerWriterTrait, InnerWriterType, LayerFailSafeReader, LayerReader, LayerWriter,
+};
 pub mod errors;
 use crate::errors::{Error, FailSafeReadError};
 
@@ -421,7 +423,7 @@ macro_rules! check_state_file_opened {
     }};
 }
 
-pub struct ArchiveWriter<'a, W: 'a + Write> {
+pub struct ArchiveWriter<'a, W: 'a + InnerWriterTrait> {
     /// MLA Archive format writer
     ///
     /// Configuration
@@ -465,7 +467,7 @@ pub fn vec_remove_item<T: std::cmp::PartialEq>(vec: &mut Vec<T>, item: &T) -> Op
     Some(vec.remove(pos))
 }
 
-impl<'a, W: Write> ArchiveWriter<'a, W> {
+impl<'a, W: InnerWriterTrait> ArchiveWriter<'a, W> {
     pub fn from_config(dest: W, config: ArchiveWriterConfig) -> Result<Self, Error> {
         // Ensure config is correct
         config.check()?;
@@ -1020,7 +1022,7 @@ impl<'b, R: 'b + Read> ArchiveFailSafeReader<'b, R> {
     /// one. On success, returns the reason conversion terminates (ideally,
     /// EndOfOriginalArchiveData)
     #[allow(clippy::cognitive_complexity)]
-    pub fn convert_to_archive<W: Write>(
+    pub fn convert_to_archive<W: InnerWriterTrait>(
         &mut self,
         output: &mut ArchiveWriter<W>,
     ) -> Result<FailSafeReadError, Error> {


### PR DESCRIPTION
Fix #120 

This PR:

* replace the inner type and trait of LayerArchiveWriter with aliases
* introduce a feature `send` for MLA, disabled by default, which make `ArchiveWriter<W>` `Send`
* add a test checking that `ArchiveWriter` is actually `Send` when the feature is on

When the feature is on, the `W` type must be `Send`. 

Forcing `Send` on the `InnerWriterType` could have been a simpler way. But it also force the user-provided type to be Sent.
Indeed, the last layer (`RawLayer`) can't be `Send` if its inner type (`W`, the user-provided one) is not `Send`.

The feature mitigates this behavior: it does not require the `W` type to be `Send`, unless the user actually need `ArchiveWriter` to be `Send`.

This behavior could have been obtain with an `unsafe` statement, but I'm trying to avoid them in MLA.