### PR TITLE
Avoid repetitive open/write/close on mlar extract

### DIFF
--- a/mlar/Cargo.toml
+++ b/mlar/Cargo.toml
@@ -27,6 +27,7 @@ zeroize = { version = "1", default-features = false}
 # Could be made optional / feature to enable (for binary size)
 tar = "0.4"
 rand_chacha = "0.3"
+lru = "0"
 
 [dev-dependencies]
 assert_cmd = "2.0"

--- a/mlar/tests/integration.rs
+++ b/mlar/tests/integration.rs
@@ -10,11 +10,9 @@ use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
 use tar::Archive;
 
-
 const SIZE_FILE1: usize = 10 * 1024 * 1024;
 const SIZE_FILE2: usize = 10 * 1024 * 1024;
 const UTIL: &str = "mlar";
-
 
 struct TestFS {
     // Files ordered by names
@@ -1265,16 +1263,13 @@ fn test_extract_lot_files() {
     // Create many files, filled with a few alphanumeric characters
     for i in 1..TEST_MANY_FILES_NB {
         let tmp_file = NamedTempFile::new(format!("file{}.bin", i)).unwrap();
-        let data: Vec<u8> = Alphanumeric
-            .sample_iter(&mut rng)
-            .take(SIZE_FILE)
-            .collect();
+        let data: Vec<u8> = Alphanumeric.sample_iter(&mut rng).take(SIZE_FILE).collect();
         tmp_file.write_binary(data.as_slice()).unwrap();
 
         files_archive_order.push(tmp_file.path().to_path_buf());
         files.push(tmp_file);
     }
-    
+
     files.sort_by(|i1, i2| Ord::cmp(&i1.path(), &i2.path()));
 
     let mut testfs = TestFS {


### PR DESCRIPTION
`mlar extract`, when no other argument are provided, is using `linear_extract` with a `FileWriter` to extract files.
To avoid consuming too much file descriptor, each file block is written with a:

1. open
2. write
3. close

pattern.
While this is fine for some usage, it could be syscall-intensive on other. For instance, if an archive is made of a files splitted in many chunks, most of the extraction time could be loss in the user<->kernel interaction.

This PR try to improve that behavior by adding a LRU cache (with an arbitrary size of 1000) on the file descriptor pool.