### PR TITLE
Fix latest clippy warnings (1.67)

### DIFF
--- a/curve25519-parser/src/lib.rs
+++ b/curve25519-parser/src/lib.rs
@@ -56,7 +56,7 @@ impl From<nom::Err<der_parser::error::BerError>> for Curve25519ParserError {
 impl fmt::Display for Curve25519ParserError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         // For now, use the debug derived version
-        write!(f, "{:?}", self)
+        write!(f, "{self:?}")
     }
 }
 

--- a/mla/benches/bench_archive.rs
+++ b/mla/benches/bench_archive.rs
@@ -63,7 +63,7 @@ pub fn multiple_layers_multiple_block_size(c: &mut Criterion) {
 
             let id = mla.start_file("file").unwrap();
             group.bench_with_input(
-                BenchmarkId::new(format!("Layers {:?}", layers), size),
+                BenchmarkId::new(format!("Layers {layers:?}"), size),
                 size,
                 |b, &_size| {
                     b.iter(|| mla.append_file_content(id, data.len() as u64, data.as_slice()));
@@ -105,7 +105,7 @@ pub fn multiple_compression_quality(c: &mut Criterion) {
 
         let id = mla.start_file("file").unwrap();
         group.bench_with_input(
-            BenchmarkId::new(format!("CompressionLevel {}", quality), size),
+            BenchmarkId::new(format!("CompressionLevel {quality}"), size),
             &size,
             |b, &_size| {
                 b.iter(|| mla.append_file_content(id, data.len() as u64, data.as_slice()));
@@ -179,7 +179,7 @@ pub fn multiple_layers_multiple_block_size_decompress(c: &mut Criterion) {
             Layers::COMPRESS | Layers::ENCRYPT,
         ] {
             group.bench_function(
-                BenchmarkId::new(format!("Layers {:?}", layers), size),
+                BenchmarkId::new(format!("Layers {layers:?}"), size),
                 move |b| b.iter_custom(|iters| iter_decompress(iters, *size as u64, *layers)),
             );
         }
@@ -210,7 +210,7 @@ fn build_archive<'a>(
             .sample_iter(&mut rng)
             .take(size as usize)
             .collect();
-        let id = mla.start_file(&format!("file_{}", i)).unwrap();
+        let id = mla.start_file(&format!("file_{i}")).unwrap();
         mla.append_file_content(id, data.len() as u64, data.as_slice())
             .unwrap();
         mla.end_file(id).unwrap();
@@ -238,7 +238,7 @@ fn iter_decompress_multifiles_random(iters: u64, size: u64, layers: Layers) -> D
     let start = Instant::now();
     for i in sample(&mut rng, iters as usize, iters as usize).iter() {
         let subfile = mla_read
-            .get_file(format!("file_{}", i).to_string())
+            .get_file(format!("file_{i}").to_string())
             .unwrap()
             .unwrap();
         let mut src = subfile.data;
@@ -267,7 +267,7 @@ pub fn multiple_layers_multiple_block_size_decompress_multifiles_random(c: &mut 
             Layers::COMPRESS | Layers::ENCRYPT,
         ] {
             group.bench_function(
-                BenchmarkId::new(format!("Layers {:?}", layers), size),
+                BenchmarkId::new(format!("Layers {layers:?}"), size),
                 move |b| {
                     b.iter_custom(|iters| {
                         iter_decompress_multifiles_random(iters, *size as u64, *layers)
@@ -319,7 +319,7 @@ pub fn linear_vs_normal_extract(c: &mut Criterion) {
             Layers::COMPRESS | Layers::ENCRYPT,
         ] {
             group.bench_function(
-                BenchmarkId::new(format!("NORMAL / Layers {:?}", layers), size),
+                BenchmarkId::new(format!("NORMAL / Layers {layers:?}"), size),
                 move |b| {
                     b.iter_custom(|iters| {
                         iter_decompress_multifiles_random(iters, *size as u64, *layers)
@@ -327,7 +327,7 @@ pub fn linear_vs_normal_extract(c: &mut Criterion) {
                 },
             );
             group.bench_function(
-                BenchmarkId::new(format!("LINEAR / Layers {:?}", layers), size),
+                BenchmarkId::new(format!("LINEAR / Layers {layers:?}"), size),
                 move |b| {
                     b.iter_custom(|iters| {
                         iter_decompress_multifiles_linear(iters, *size as u64, *layers)

--- a/mla/src/errors.rs
+++ b/mla/src/errors.rs
@@ -62,7 +62,7 @@ pub enum Error {
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         // For now, use the debug derived version
-        write!(f, "{:?}", self)
+        write!(f, "{self:?}")
     }
 }
 
@@ -92,7 +92,7 @@ impl From<bincode::ErrorKind> for Error {
 
 impl From<Error> for io::Error {
     fn from(error: Error) -> Self {
-        io::Error::new(io::ErrorKind::Other, format!("{}", error))
+        io::Error::new(io::ErrorKind::Other, format!("{error}"))
     }
 }
 
@@ -165,7 +165,7 @@ pub enum FailSafeReadError {
 impl fmt::Display for FailSafeReadError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         // For now, use the debug derived version
-        write!(f, "{:?}", self)
+        write!(f, "{self:?}")
     }
 }
 
@@ -195,7 +195,7 @@ pub enum ConfigError {
 impl fmt::Display for ConfigError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         // For now, use the debug derived version
-        write!(f, "{:?}", self)
+        write!(f, "{self:?}")
     }
 }
 

--- a/mla/src/helpers.rs
+++ b/mla/src/helpers.rs
@@ -3,7 +3,7 @@ use super::layers::traits::InnerWriterTrait;
 use super::{ArchiveFileBlock, ArchiveFileID, ArchiveReader, ArchiveWriter, Error};
 use std::collections::HashMap;
 use std::hash::BuildHasher;
-use std::io::{self, Read, Seek, SeekFrom, Write};
+use std::io::{self, Read, Seek, Write};
 
 /// Extract an Archive linearly.
 ///
@@ -24,7 +24,7 @@ pub fn linear_extract<W1: InnerWriterTrait, R: Read + Seek, S: BuildHasher>(
     export: &mut HashMap<&String, W1, S>,
 ) -> Result<(), Error> {
     // Seek at the beginning
-    archive.src.seek(SeekFrom::Start(0))?;
+    archive.src.rewind()?;
 
     // Use a BufReader to cache, by merging them into one bigger read, small
     // read calls (like the ones on ArchiveFileBlock reading)

--- a/mla/src/layers/compress.rs
+++ b/mla/src/layers/compress.rs
@@ -149,7 +149,7 @@ impl<R: Read> CompressionLayerReaderState<R> {
 
 impl<'a, R: 'a + Read> CompressionLayerReader<'a, R> {
     pub fn new(mut inner: Box<dyn 'a + LayerReader<'a, R>>) -> Result<Self, Error> {
-        let underlayer_pos = inner.seek(SeekFrom::Current(0))?;
+        let underlayer_pos = inner.stream_position()?;
         Ok(Self {
             state: CompressionLayerReaderState::Ready(inner),
             sizes_info: None,
@@ -797,7 +797,7 @@ mod tests {
         let mut reader = brotli::Decompressor::new(&mut src, 0);
         let mut buf = Vec::new();
         reader.read_to_end(&mut buf).unwrap();
-        println!("{:?}", buf);
+        println!("{buf:?}");
         fake_data.extend(fake_data2);
         assert_eq!(fake_data, buf);
     }

--- a/mla/src/layers/encrypt.rs
+++ b/mla/src/layers/encrypt.rs
@@ -356,7 +356,7 @@ impl<'a, R: 'a + Read + Seek> LayerReader<'a, R> for EncryptionLayerReader<'a, R
         self.inner.initialize()?;
 
         // Load the current buffer in cache
-        self.seek(SeekFrom::Start(0))?;
+        self.rewind()?;
         Ok(())
     }
 }
@@ -645,7 +645,7 @@ mod tests {
         assert_eq!(output, FAKE_FILE);
 
         // Seek and decrypt twice the same thing
-        let pos = encrypt_r.seek(SeekFrom::Current(0)).unwrap();
+        let pos = encrypt_r.stream_position().unwrap();
         // test the current position retrievial
         assert_eq!(pos, tag_position_to_no_tag_position(FAKE_FILE.len() as u64));
         // decrypt twice the same thing, with an offset
@@ -653,7 +653,7 @@ mod tests {
         assert_eq!(pos, 5);
         let mut output = Vec::new();
         encrypt_r.read_to_end(&mut output).unwrap();
-        println!("{:?}", output);
+        println!("{output:?}");
         assert_eq!(output.as_slice(), &FAKE_FILE[5..]);
     }
 

--- a/mla/src/layers/raw.rs
+++ b/mla/src/layers/raw.rs
@@ -65,7 +65,7 @@ impl<R: Read + Seek> RawLayerReader<R> {
 
     /// Mark the current position as the position 0
     pub fn reset_position(&mut self) -> io::Result<()> {
-        self.offset_pos = self.inner.seek(SeekFrom::Current(0))?;
+        self.offset_pos = self.inner.stream_position()?;
         Ok(())
     }
 }
@@ -206,26 +206,21 @@ mod tests {
 
         // Start playing with relative seek
         raw_r.reset_position().unwrap();
-        assert_eq!(raw_r.seek(SeekFrom::Current(0)).unwrap(), 0);
+        assert_eq!(raw_r.stream_position().unwrap(), 0);
         assert_eq!(raw_r.seek(SeekFrom::Current(-1)).unwrap(), 0);
         assert_eq!(raw_r.seek(SeekFrom::Current(1)).unwrap(), 1);
         let mut buf = Vec::new();
         raw_r.read_to_end(&mut buf).unwrap();
         assert_eq!(buf.as_slice(), b"bcdef");
-        assert_eq!(
-            raw_r.seek(SeekFrom::Current(0)).unwrap(),
-            data2.len() as u64
-        );
+        assert_eq!(raw_r.stream_position().unwrap(), data2.len() as u64);
 
-        assert_eq!(raw_r.seek(SeekFrom::Start(0)).unwrap(), 0);
+        raw_r.rewind().unwrap();
+        assert_eq!(raw_r.stream_position().unwrap(), 0);
         assert_eq!(raw_r.seek(SeekFrom::Start(3)).unwrap(), 3);
         let mut buf = Vec::new();
         raw_r.read_to_end(&mut buf).unwrap();
         assert_eq!(buf.as_slice(), b"def");
-        assert_eq!(
-            raw_r.seek(SeekFrom::Current(0)).unwrap(),
-            data2.len() as u64
-        );
+        assert_eq!(raw_r.stream_position().unwrap(), data2.len() as u64);
 
         assert_eq!(raw_r.seek(SeekFrom::End(0)).unwrap(), data2.len() as u64);
         assert_eq!(raw_r.seek(SeekFrom::End(-6)).unwrap(), 0);
@@ -234,10 +229,7 @@ mod tests {
         let mut buf = Vec::new();
         raw_r.read_to_end(&mut buf).unwrap();
         assert_eq!(buf.as_slice(), b"cdef");
-        assert_eq!(
-            raw_r.seek(SeekFrom::Current(0)).unwrap(),
-            data2.len() as u64
-        );
+        assert_eq!(raw_r.stream_position().unwrap(), data2.len() as u64);
     }
 
     #[test]

--- a/mlar/src/main.rs
+++ b/mlar/src/main.rs
@@ -22,7 +22,7 @@ use std::error;
 use std::fmt;
 use std::fs::{self, read_dir, File};
 use std::io::{self, BufRead};
-use std::io::{Read, Seek, SeekFrom, Write};
+use std::io::{Read, Seek, Write};
 use std::path::{Component, Path, PathBuf};
 use tar::{Builder, Header};
 
@@ -43,7 +43,7 @@ pub enum MlarError {
 impl fmt::Display for MlarError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         // For now, use the debug derived version
-        write!(f, "{:?}", self)
+        write!(f, "{self:?}")
     }
 }
 
@@ -255,7 +255,7 @@ fn open_mla_file<'a>(matches: &ArgMatches) -> Result<ArchiveReader<'a, File>, Ml
 
     // If a decryption key is provided, assume the user expects the file to be encrypted
     // If not, avoid opening it
-    file.seek(SeekFrom::Start(0))?;
+    file.rewind()?;
     let header = ArchiveHeader::from(&mut file)?;
     if config.layers_enabled.contains(Layers::ENCRYPT)
         && !header.config.layers_enabled.contains(Layers::ENCRYPT)
@@ -263,7 +263,7 @@ fn open_mla_file<'a>(matches: &ArgMatches) -> Result<ArchiveReader<'a, File>, Ml
         eprintln!("[-] A private key has been provided, but the archive is not encrypted");
         return Err(MlarError::PrivateKeyProvidedButNotUsed);
     }
-    file.seek(SeekFrom::Start(0))?;
+    file.rewind()?;
 
     // Instantiate reader
     Ok(ArchiveReader::from_config(file, config)?)
@@ -328,7 +328,7 @@ impl ExtractFileNameMatcher {
                     .map(|pat| {
                         Pattern::new(pat)
                             .map_err(|err| {
-                                eprintln!("[!] Invalid glob pattern {:?} ({:?})", pat, err);
+                                eprintln!("[!] Invalid glob pattern {pat:?} ({err:?})");
                             })
                             .expect("Invalid glob pattern")
                     })
@@ -369,10 +369,7 @@ fn get_extracted_path(output_dir: &Path, file_name: &str) -> Option<PathBuf> {
             // security issues.  See, e.g.: CVE-2001-1267,
             // CVE-2002-0399, CVE-2005-1918, CVE-2007-4131
             Component::ParentDir => {
-                eprintln!(
-                    "[!] Skipping file \"{}\" because it contains \"..\"",
-                    file_name
-                );
+                eprintln!("[!] Skipping file \"{file_name}\" because it contains \"..\"");
                 return None;
             }
 
@@ -432,7 +429,7 @@ fn create_file<P1: AsRef<Path>>(
     }
     Ok(Some((
         File::create(&extracted_path).map_err(|err| {
-            eprintln!(" [!] Unable to create \"{}\" ({:?})", fname, err);
+            eprintln!(" [!] Unable to create \"{fname}\" ({err:?})");
             err
         })?,
         extracted_path,
@@ -474,7 +471,7 @@ fn add_file_or_dir(mla: &mut ArchiveWriter<OutputTypes>, path: &Path) -> Result<
         let filename = path.to_string_lossy();
         let file = File::open(path)?;
         let length = file.metadata()?.len();
-        eprintln!("{}", filename);
+        eprintln!("{filename}");
         mla.add_file(&filename, length, file)?;
     }
     Ok(())
@@ -524,13 +521,13 @@ fn list(matches: &ArgMatches) -> Result<(), MlarError> {
     iter.sort();
     for fname in iter {
         if matches.get_count("verbose") == 0 {
-            println!("{}", fname);
+            println!("{fname}");
         } else {
             let mla_file = mla.get_file(fname)?.expect("Unable to get the file");
             let filename = mla_file.filename;
             let size = mla_file.size.format_size(DECIMAL);
             if matches.get_count("verbose") == 1 {
-                println!("{} - {}", filename, size);
+                println!("{filename} - {size}");
             } else if matches.get_count("verbose") >= 2 {
                 let hash = mla.get_hash(&filename)?.expect("Unable to get the hash");
                 println!("{} - {} ({})", filename, size, hex::encode(hash),);
@@ -596,17 +593,11 @@ fn extract(matches: &ArgMatches) -> Result<(), MlarError> {
         // Look for the file in the archive
         let mut sub_file = match mla.get_file(fname.clone()) {
             Err(err) => {
-                eprintln!(
-                    " [!] Error while looking up subfile \"{}\" ({:?})",
-                    fname, err
-                );
+                eprintln!(" [!] Error while looking up subfile \"{fname}\" ({err:?})",);
                 continue;
             }
             Ok(None) => {
-                eprintln!(
-                    " [!] Subfile \"{}\" indexed in metadata could not be found",
-                    fname
-                );
+                eprintln!(" [!] Subfile \"{fname}\" indexed in metadata could not be found");
                 continue;
             }
             Ok(Some(subfile)) => subfile,
@@ -617,10 +608,10 @@ fn extract(matches: &ArgMatches) -> Result<(), MlarError> {
         };
 
         if verbose {
-            println!("{}", fname);
+            println!("{fname}");
         }
         io::copy(&mut sub_file.data, &mut extracted_file).map_err(|err| {
-            eprintln!(" [!] Unable to extract \"{}\" ({:?})", fname, err);
+            eprintln!(" [!] Unable to extract \"{fname}\" ({err:?})");
             err
         })?;
     }
@@ -641,7 +632,7 @@ fn cat(matches: &ArgMatches) -> Result<(), MlarError> {
             let pat = match Pattern::new(arg_pattern) {
                 Ok(pat) => pat,
                 Err(err) => {
-                    eprintln!(" [!] Invalid glob pattern {:?} ({:?})", arg_pattern, err);
+                    eprintln!(" [!] Invalid glob pattern {arg_pattern:?} ({err:?})");
                     continue;
                 }
             };
@@ -651,19 +642,18 @@ fn cat(matches: &ArgMatches) -> Result<(), MlarError> {
                 }
                 match mla.get_file(fname.to_string()) {
                     Err(err) => {
-                        eprintln!(" [!] Error while looking up file \"{}\" ({:?})", fname, err);
+                        eprintln!(" [!] Error while looking up file \"{fname}\" ({err:?})");
                         continue;
                     }
                     Ok(None) => {
                         eprintln!(
-                            " [!] Subfile \"{}\" indexed in metadata could not be found",
-                            fname
+                            " [!] Subfile \"{fname}\" indexed in metadata could not be found"
                         );
                         continue;
                     }
                     Ok(Some(mut subfile)) => {
                         io::copy(&mut subfile.data, &mut destination).map_err(|err| {
-                            eprintln!(" [!] Unable to extract \"{}\" ({:?})", fname, err);
+                            eprintln!(" [!] Unable to extract \"{fname}\" ({err:?})");
                             err
                         })?;
                     }
@@ -675,16 +665,16 @@ fn cat(matches: &ArgMatches) -> Result<(), MlarError> {
         for fname in files_values {
             match mla.get_file(fname.to_string()) {
                 Err(err) => {
-                    eprintln!(" [!] Error while looking up file \"{}\" ({:?})", fname, err);
+                    eprintln!(" [!] Error while looking up file \"{fname}\" ({err:?})");
                     continue;
                 }
                 Ok(None) => {
-                    eprintln!(" [!] File not found: \"{}\"", fname);
+                    eprintln!(" [!] File not found: \"{fname}\"");
                     continue;
                 }
                 Ok(Some(mut subfile)) => {
                     io::copy(&mut subfile.data, &mut destination).map_err(|err| {
-                        eprintln!(" [!] Unable to extract \"{}\" ({:?})", fname, err);
+                        eprintln!(" [!] Unable to extract \"{fname}\" ({err:?})");
                         err
                     })?;
                 }
@@ -707,26 +697,17 @@ fn to_tar(matches: &ArgMatches) -> Result<(), MlarError> {
     for fname in archive_files {
         let sub_file = match mla.get_file(fname.clone()) {
             Err(err) => {
-                eprintln!(
-                    " [!] Error while looking up subfile \"{}\" ({:?})",
-                    fname, err
-                );
+                eprintln!(" [!] Error while looking up subfile \"{fname}\" ({err:?})");
                 continue;
             }
             Ok(None) => {
-                eprintln!(
-                    " [!] Subfile \"{}\" indexed in metadata could not be found",
-                    fname
-                );
+                eprintln!(" [!] Subfile \"{fname}\" indexed in metadata could not be found");
                 continue;
             }
             Ok(Some(subfile)) => subfile,
         };
         if let Err(err) = add_file_to_tar(&mut tar_file, sub_file) {
-            eprintln!(
-                " [!] Unable to add subfile \"{}\" to tarball ({:?})",
-                fname, err
-            );
+            eprintln!(" [!] Unable to add subfile \"{fname}\" to tarball ({err:?})");
         }
     }
     Ok(())
@@ -744,7 +725,7 @@ fn repair(matches: &ArgMatches) -> Result<(), MlarError> {
             eprintln!("[WARNING] The whole archive has been recovered");
         }
         _ => {
-            eprintln!("[WARNING] Conversion ends with {}", status);
+            eprintln!("[WARNING] Conversion ends with {status}");
         }
     };
     Ok(())
@@ -764,14 +745,14 @@ fn convert(matches: &ArgMatches) -> Result<(), MlarError> {
 
     // Convert
     for fname in fnames {
-        eprintln!("{}", fname);
+        eprintln!("{fname}");
         let sub_file = match mla.get_file(fname.clone()) {
             Err(err) => {
-                eprintln!("Error while adding {} ({:?})", fname, err);
+                eprintln!("Error while adding {fname} ({err:?})");
                 continue;
             }
             Ok(None) => {
-                eprintln!("Unable to found {}", fname);
+                eprintln!("Unable to found {fname}");
                 continue;
             }
             Ok(Some(mla)) => mla,
@@ -828,7 +809,7 @@ impl ArchiveInfoReader {
         R: 'a + Read + Seek,
     {
         // Make sure we read the archive header from the start
-        src.seek(SeekFrom::Start(0))?;
+        src.rewind()?;
         let header = ArchiveHeader::from(&mut src)?;
         config.load_persistent(header.config)?;
 
@@ -857,7 +838,7 @@ impl ArchiveInfoReader {
 
         let metadata = Some(ArchiveFooter::deserialize_from(&mut src)?);
 
-        src.seek(SeekFrom::Start(0))?;
+        src.rewind()?;
         Ok(ArchiveInfoReader {
             config,
             compressed_size,
@@ -898,7 +879,7 @@ fn info(matches: &ArgMatches) -> Result<(), MlarError> {
     println!("Format version: {}", header.format_version);
 
     // Encryption config
-    println!("Encryption: {}", encryption);
+    println!("Encryption: {encryption}");
     if encryption && matches.get_flag("verbose") {
         let encrypt_config = header.config.encrypt.expect("Encryption config not found");
         println!(
@@ -908,13 +889,13 @@ fn info(matches: &ArgMatches) -> Result<(), MlarError> {
     }
 
     // Compression config
-    println!("Compression: {}", compression);
+    println!("Compression: {compression}");
     if compression && matches.get_flag("verbose") {
         let mla_ = mla.expect("MLA is required for verbose compression info");
         let output_size = mla_.get_files_size()?;
         let compressed_size: u64 = mla_.compressed_size.expect("Missing compression size");
         let compression_rate = output_size as f64 / compressed_size as f64;
-        println!("  Compression rate: {:.2}", compression_rate);
+        println!("  Compression rate: {compression_rate:.2}");
     }
 
     Ok(())
@@ -1134,7 +1115,7 @@ fn main() {
     };
 
     if let Err(err) = res {
-        eprintln!("[!] Command ended with error: {:?}", err);
+        eprintln!("[!] Command ended with error: {err:?}");
         std::process::exit(1);
     }
 }

--- a/mlar/tests/integration.rs
+++ b/mlar/tests/integration.rs
@@ -145,7 +145,7 @@ fn test_help() {
     cmd.arg("--help");
 
     // Ensure the basic help display is working
-    println!("{:?}", cmd);
+    println!("{cmd:?}");
     let assert = cmd.assert();
     assert.success();
 }
@@ -181,7 +181,7 @@ fn test_create_from_dir() {
     // result of `read_dir` which is plateform and filesystem dependent.
     file_list_append_from_dir(tmp_dir.path(), &mut file_list);
 
-    println!("{:?}", cmd);
+    println!("{cmd:?}");
     let assert = cmd.assert();
     assert.success().stderr(file_list.join("\n") + "\n");
 
@@ -193,7 +193,7 @@ fn test_create_from_dir() {
         .arg("-k")
         .arg(ecc_private);
 
-    println!("{:?}", cmd);
+    println!("{cmd:?}");
     let assert = cmd.assert();
     file_list.sort();
     assert.success().stdout(file_list.join("\n") + "\n");
@@ -217,14 +217,14 @@ fn test_create_filelist_stdin() {
         .arg(ecc_public);
 
     cmd.arg("-");
-    println!("{:?}", cmd);
+    println!("{cmd:?}");
 
     let mut file_list = String::new();
     for file in &testfs.files {
         file_list.push_str(format!("{}\n", file.path().to_string_lossy()).as_str());
     }
     cmd.write_stdin(String::from(&file_list));
-    println!("{:?}", file_list);
+    println!("{file_list:?}");
     let assert = cmd.assert();
     assert.success().stderr(String::from(&file_list));
 
@@ -236,7 +236,7 @@ fn test_create_filelist_stdin() {
         .arg("-k")
         .arg(ecc_private);
 
-    println!("{:?}", cmd);
+    println!("{cmd:?}");
     let assert = cmd.assert();
     assert.success().stdout(file_list);
 }
@@ -265,7 +265,7 @@ fn test_create_list_tar() {
         file_list.push_str(format!("{}\n", file.path().to_string_lossy()).as_str());
     }
 
-    println!("{:?}", cmd);
+    println!("{cmd:?}");
     let assert = cmd.assert();
     assert.success().stderr(String::from(&file_list));
 
@@ -277,7 +277,7 @@ fn test_create_list_tar() {
         .arg("-k")
         .arg(ecc_private);
 
-    println!("{:?}", cmd);
+    println!("{cmd:?}");
     let assert = cmd.assert();
     assert.success().stdout(file_list);
 
@@ -291,7 +291,7 @@ fn test_create_list_tar() {
         .arg("-o")
         .arg(tar_file.path());
 
-    println!("{:?}", cmd);
+    println!("{cmd:?}");
     let assert = cmd.assert();
     assert.success();
 
@@ -330,7 +330,7 @@ fn test_truncated_repair_list_tar() {
         file_list.push_str(format!("{}\n", path.to_string_lossy()).as_str());
     }
 
-    println!("{:?}", cmd);
+    println!("{cmd:?}");
     let assert = cmd.assert();
     assert.success().stderr(String::from(&file_list));
 
@@ -357,7 +357,7 @@ fn test_truncated_repair_list_tar() {
         .arg("-o")
         .arg(mlar_repaired_file.path());
 
-    println!("{:?}", cmd);
+    println!("{cmd:?}");
     let assert = cmd.assert();
     assert.success();
 
@@ -369,7 +369,7 @@ fn test_truncated_repair_list_tar() {
         .arg("-k")
         .arg(ecc_private);
 
-    println!("{:?}", cmd);
+    println!("{cmd:?}");
     let assert = cmd.assert();
     // Do not consider the last file for test after trunc, as we truncate at
     // 6 / 7 (last file being really small)
@@ -385,7 +385,7 @@ fn test_truncated_repair_list_tar() {
         .arg("-o")
         .arg(tar_file.path());
 
-    println!("{:?}", cmd);
+    println!("{cmd:?}");
     let assert = cmd.assert();
     assert.success();
 
@@ -459,7 +459,7 @@ fn test_multiple_keys() {
         file_list.push_str(format!("{}\n", file.path().to_string_lossy()).as_str());
     }
 
-    println!("{:?}", cmd);
+    println!("{cmd:?}");
     let assert = cmd.assert();
     assert.success().stderr(String::from(&file_list));
 
@@ -478,7 +478,7 @@ fn test_multiple_keys() {
         .arg("-k")
         .arg(ecc_privates[1]);
 
-    println!("{:?}", cmd);
+    println!("{cmd:?}");
     let assert = cmd.assert();
     assert.success().stdout(String::from(&file_list));
 
@@ -490,7 +490,7 @@ fn test_multiple_keys() {
         .arg("-k")
         .arg(Path::new("../samples/test_x25519_3.pem"));
 
-    println!("{:?}", cmd);
+    println!("{cmd:?}");
     let assert = cmd.assert();
     assert.success().stdout(String::from(&file_list));
 
@@ -502,7 +502,7 @@ fn test_multiple_keys() {
         .arg("-k")
         .arg(ecc_privates[1]);
 
-    println!("{:?}", cmd);
+    println!("{cmd:?}");
     let assert = cmd.assert();
     assert.failure();
 }
@@ -534,7 +534,7 @@ fn test_multiple_compression_level() {
             file_list.push_str(format!("{}\n", file.path().to_string_lossy()).as_str());
         }
 
-        println!("{:?}", cmd);
+        println!("{cmd:?}");
         let assert = cmd.assert();
         assert.success().stderr(String::from(&file_list));
     }
@@ -554,7 +554,7 @@ fn test_multiple_compression_level() {
             .arg("-o")
             .arg(tar_name.path());
 
-        println!("{:?}", cmd);
+        println!("{cmd:?}");
         let assert = cmd.assert();
         assert.success();
     }
@@ -591,7 +591,7 @@ fn test_convert() {
         file_list.push_str(format!("{}\n", file.path().to_string_lossy()).as_str());
     }
 
-    println!("{:?}", cmd);
+    println!("{cmd:?}");
     let assert = cmd.assert();
     assert.success().stderr(String::from(&file_list));
 
@@ -609,7 +609,7 @@ fn test_convert() {
         .arg("-p")
         .arg(ecc_public2);
 
-    println!("{:?}", cmd);
+    println!("{cmd:?}");
     let assert = cmd.assert();
     assert.success().stderr(String::from(&file_list));
 
@@ -628,7 +628,7 @@ fn test_convert() {
         .arg("-o")
         .arg(tar_file.path());
 
-    println!("{:?}", cmd);
+    println!("{cmd:?}");
     let assert = cmd.assert();
     assert.success();
 
@@ -661,7 +661,7 @@ fn test_stdio() {
         file_list.push_str(format!("{}\n", file.path().to_string_lossy()).as_str());
     }
 
-    println!("{:?}", cmd);
+    println!("{cmd:?}");
     let assert = cmd.assert();
     let archive_data = assert.get_output().stdout.clone();
     assert.success().stderr(String::from(&file_list));
@@ -680,7 +680,7 @@ fn test_stdio() {
         .arg("-o")
         .arg(tar_file.path());
 
-    println!("{:?}", cmd);
+    println!("{cmd:?}");
     let assert = cmd.assert();
     assert.success();
 
@@ -727,7 +727,7 @@ fn test_multi_fileorders() {
             file_list.push_str(format!("{}\n", file.to_string_lossy()).as_str());
         }
 
-        println!("{:?}", cmd);
+        println!("{cmd:?}");
         let assert = cmd.assert();
         assert.success().stderr(String::from(&file_list));
 
@@ -741,7 +741,7 @@ fn test_multi_fileorders() {
             .arg("-o")
             .arg(tar_file.path());
 
-        println!("{:?}", cmd);
+        println!("{cmd:?}");
         let assert = cmd.assert();
         assert.success();
 
@@ -765,7 +765,7 @@ fn test_verbose_listing() {
         file_list.push_str(format!("{}\n", file.path().to_string_lossy()).as_str());
     }
 
-    println!("{:?}", cmd);
+    println!("{cmd:?}");
     let assert = cmd.assert();
     assert.success().stderr(String::from(&file_list));
 
@@ -773,7 +773,7 @@ fn test_verbose_listing() {
     let mut cmd = Command::cargo_bin(UTIL).unwrap();
     cmd.arg("list").arg("-i").arg(mlar_file.path());
 
-    println!("{:?}", cmd);
+    println!("{cmd:?}");
     let assert = cmd.assert();
     assert.success().stdout(file_list);
 
@@ -781,7 +781,7 @@ fn test_verbose_listing() {
     let mut cmd = Command::cargo_bin(UTIL).unwrap();
     cmd.arg("list").arg("-v").arg("-i").arg(mlar_file.path());
 
-    println!("{:?}", cmd);
+    println!("{cmd:?}");
     let assert = cmd.assert();
     assert.success();
 
@@ -789,7 +789,7 @@ fn test_verbose_listing() {
     let mut cmd = Command::cargo_bin(UTIL).unwrap();
     cmd.arg("list").arg("-vv").arg("-i").arg(mlar_file.path());
 
-    println!("{:?}", cmd);
+    println!("{cmd:?}");
     let assert = cmd.assert();
     assert.success();
 }
@@ -809,7 +809,7 @@ fn test_extract() {
         file_list.push_str(format!("{}\n", file.path().to_string_lossy()).as_str());
     }
 
-    println!("{:?}", cmd);
+    println!("{cmd:?}");
     let assert = cmd.assert();
     assert.success().stderr(String::from(&file_list));
 
@@ -832,7 +832,7 @@ fn test_extract() {
         .arg("-g")
         .arg("*");
 
-    println!("{:?}", cmd);
+    println!("{cmd:?}");
     let assert = cmd.assert();
     assert.success().stdout(file_list);
 
@@ -850,7 +850,7 @@ fn test_extract() {
         .arg("-o")
         .arg(output_dir.path());
 
-    println!("{:?}", cmd);
+    println!("{cmd:?}");
     let assert = cmd.assert();
     assert
         .success()
@@ -884,7 +884,7 @@ fn test_extract() {
         .arg(output_dir.path())
         .arg(one_filename);
 
-    println!("{:?}", cmd);
+    println!("{cmd:?}");
     let assert = cmd.assert();
     assert
         .success()
@@ -905,7 +905,7 @@ fn test_extract() {
         .arg("-g")
         .arg("*file1*");
 
-    println!("{:?}", cmd);
+    println!("{cmd:?}");
     let assert = cmd.assert();
     assert
         .success()
@@ -929,7 +929,7 @@ fn test_cat() {
         file_list.push_str(format!("{}\n", file.path().to_string_lossy()).as_str());
     }
 
-    println!("{:?}", cmd);
+    println!("{cmd:?}");
     let assert = cmd.assert();
     assert.success().stderr(String::from(&file_list));
 
@@ -940,7 +940,7 @@ fn test_cat() {
         .arg(mlar_file.path())
         .arg(&testfs.files_archive_order[2]);
 
-    println!("{:?}", cmd);
+    println!("{cmd:?}");
     let assert = cmd.assert();
 
     let mut expected_content = Vec::new();
@@ -978,7 +978,7 @@ fn test_keygen() {
         file_list.push_str(format!("{}\n", file.path().to_string_lossy()).as_str());
     }
 
-    println!("{:?}", cmd);
+    println!("{cmd:?}");
     let assert = cmd.assert();
     assert.success().stderr(String::from(&file_list));
 
@@ -990,7 +990,7 @@ fn test_keygen() {
         .arg("-i")
         .arg(mlar_file.path());
 
-    println!("{:?}", cmd);
+    println!("{cmd:?}");
     let assert = cmd.assert();
     assert.success().stdout(file_list);
 }
@@ -1018,7 +1018,7 @@ fn test_verbose_info() {
         file_list.push_str(format!("{}\n", file.path().to_string_lossy()).as_str());
     }
 
-    println!("{:?}", cmd);
+    println!("{cmd:?}");
     let assert = cmd.assert();
     assert.success().stderr(String::from(&file_list));
 
@@ -1030,7 +1030,7 @@ fn test_verbose_info() {
         .arg("-i")
         .arg(mlar_file.path());
 
-    println!("{:?}", cmd);
+    println!("{cmd:?}");
     let assert = cmd.assert();
     assert.success().stdout(
         "Format version: 1
@@ -1048,7 +1048,7 @@ Compression: true
         .arg("-i")
         .arg(mlar_file.path());
 
-    println!("{:?}", cmd);
+    println!("{cmd:?}");
     let assert = cmd.assert();
     assert.success();
 }
@@ -1076,7 +1076,7 @@ fn test_no_open_on_encrypt() {
         file_list.push_str(format!("{}\n", file.path().to_string_lossy()).as_str());
     }
 
-    println!("{:?}", cmd);
+    println!("{cmd:?}");
     let assert = cmd.assert();
     assert.success().stderr(String::from(&file_list));
 
@@ -1091,7 +1091,7 @@ fn test_no_open_on_encrypt() {
         .arg("-k")
         .arg(ecc_private);
 
-    println!("{:?}", cmd);
+    println!("{cmd:?}");
     let assert = cmd.assert();
     assert.failure();
 }


### PR DESCRIPTION
Changes in clippy 1.67 prevent CI checks (https://github.com/rust-lang/rust-clippy/blob/master/CHANGELOG.md)