### PR TITLE
Implements a key derivation scheme and a fixed seed key generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -487,3 +487,20 @@ By default, `MLAArchiveWriter` is not `Send`. If the inner writable type is also
 [dependencies]
 mla = { version = "...", default-features = false, features = ["send"]}
 ```
+
+**How to deterministically generate a key-pair?**
+
+The option `--seed` of `mlar keygen` can be used to deterministically generate a key-pair. For instance, it can be used for reproductive testing or archiving a key in a safe.
+
+:warning: It is not recommended to use a `seed` unless one knows why she is doing it.
+The security of the resulting private-key is dependent of the security of the seed. In particular:
+
+- if an attacker known the `seed`, he knowns the private-key
+- the entropy of the resulting private-key is at most the one of the `seed`
+
+The algorithm used for the generation is as follow:
+
+1. given a `seed`, encode it as an UTF8 sequence of bytes `bytes`
+1. `prng_seed = SHA512(bytes)[0..32]`
+1. `secret = ChaCha-20rounds(prng_seed)`
+1. `secret`, after being clamped as specified by the Curve-25519 reference, is used as the private key

--- a/README.md
+++ b/README.md
@@ -504,3 +504,48 @@ The algorithm used for the generation is as follow:
 1. `prng_seed = SHA512(bytes)[0..32]`
 1. `secret = ChaCha-20rounds(prng_seed)`
 1. `secret`, after being clamped as specified by the Curve-25519 reference, is used as the private key
+
+**How to setup a "hierarchical key infrastructure"?**
+
+`mlar` provides a subcommand `keyderive` to deterministically derive sub-key from a given key along a derivation path (a bit like [BIP-32](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki), except children public keys can't be derived from the parent one).
+
+For instance, if one wants to derive the following scheme:
+```ascii
+root_key
+    ├──["App X"]── key_app_x
+    │   └──["v1.2.3"]── key_app_x_v1.2.3
+    └──["App Y"]── key_app_y
+```
+
+One can use the following commands:
+```bash
+# Create the root key (--seed can be used if this key must be created deterministically, see above)
+mlar keygen root_key
+# Create App keys
+mlar keyderive root_key key_app_x --path "App X"
+mlar keyderive root_key key_app_y --path "App Y"
+# Create the v1.2.3 key of App X
+mlar keyderive key_app_x key_app_x_v1.2.3 --path "v1.2.3"
+```
+
+At this point, let's consider an outage happened and keys have been lost.
+
+One can recover all the keys from the `root_key` private key.
+For instance, to recover the `key_app_v1.2.3`:
+```bash
+mlar keyderive root_key recovered_key --path "App X" --path "v1.2.3"
+```
+
+As such, if the `App X` owner only knows `key_app_x`, he can recover all of its subkeys, including `key_app_v1.2.3` but excluding `key_app_y`.
+
+:warning: This scheme does not provide any revocation mechanism. If a parent key is compromised, all of the key in its sub-tree must be considered compromised (ie. all past and futures key that can be obtained from it). The opposite is not true: a parent key remains safe if any of its children key is compromised.
+
+The algorithm used for the generation is as follow:
+
+1. Given a `private key`, extract it's `secret` as a 32-bytes value (the clamped private key of Curve 25519)
+1. For each `path` encoded as UTF8:
+   
+    1. Derive a seed from a HKDF-SHA512 function (RFC5869) with: `HKDF-SHA512(salt="PATH DERIVATION" ASCII-encoded, ikm=secret extracted from the parent key, info=Derivation path)`
+    1. Use the first 32-bytes as a seed for a ChaCha-20 rounds PRNG
+    1. The first 32-bytes output of ChaCha, after being clamped as specified by the Curve-25519 reference, is used as the new private key
+1. Use the last computed private key as the resulting key

--- a/mlar/Cargo.toml
+++ b/mlar/Cargo.toml
@@ -21,6 +21,7 @@ rand = "0.8"
 x25519-dalek = "1"
 humansize = {version = "2", features = ["impl_style"]}
 hex = "0.4"
+sha2 = { version = "0", default-features = false}
 # Could be made optional / feature to enable (for binary size)
 tar = "0.4"
 rand_chacha = "0.3"

--- a/mlar/Cargo.toml
+++ b/mlar/Cargo.toml
@@ -22,6 +22,8 @@ x25519-dalek = "1"
 humansize = {version = "2", features = ["impl_style"]}
 hex = "0.4"
 sha2 = { version = "0", default-features = false}
+hkdf = { version = "0", default-features = false}
+zeroize = { version = "1", default-features = false}
 # Could be made optional / feature to enable (for binary size)
 tar = "0.4"
 rand_chacha = "0.3"

--- a/mlar/src/main.rs
+++ b/mlar/src/main.rs
@@ -1,8 +1,9 @@
 use clap::{value_parser, Arg, ArgAction, ArgMatches, Command};
 use curve25519_parser::{
-    generate_keypair, parse_openssl_25519_privkey, parse_openssl_25519_pubkey,
+    generate_keypair, parse_openssl_25519_privkey, parse_openssl_25519_pubkey, StaticSecret,
 };
 use glob::Pattern;
+use hkdf::Hkdf;
 use humansize::{FormatSize, DECIMAL};
 use mla::config::{ArchiveReaderConfig, ArchiveWriterConfig};
 use mla::errors::{Error, FailSafeReadError};
@@ -26,6 +27,7 @@ use std::io::{self, BufRead};
 use std::io::{Read, Seek, Write};
 use std::path::{Component, Path, PathBuf};
 use tar::{Builder, Header};
+use zeroize::Zeroize;
 
 // ----- Error ------
 
@@ -805,6 +807,69 @@ fn keygen(matches: &ArgMatches) -> Result<(), MlarError> {
     Ok(())
 }
 
+const DERIVE_PATH_SALT: &[u8; 15] = b"PATH DERIVATION";
+
+/// Derive a Curve25519 secret along a path and return a seed
+///
+/// HKDF(salt="PATH DERIVATION", ikm=Parent Key, info=Derivation path) -> seed
+fn apply_derive(path: &str, mut src: StaticSecret) -> [u8; 32] {
+    let hkdf: Hkdf<Sha512> = Hkdf::new(Some(DERIVE_PATH_SALT), &src.to_bytes());
+    let mut seed = [0u8; 32];
+    hkdf.expand(path.as_bytes(), &mut seed)
+        .expect("[ERROR] Error while expanding the key");
+    src.zeroize();
+    seed
+}
+
+#[allow(clippy::unnecessary_wraps)]
+fn keyderive(matches: &ArgMatches) -> Result<(), MlarError> {
+    // Safe to use unwrap() because of the requirement
+    let output_base = matches.get_one::<PathBuf>("output").unwrap();
+
+    let mut output_pub = File::create(Path::new(output_base).with_extension("pub"))
+        .expect("Unable to create the public file");
+    let mut output_priv = File::create(output_base).expect("Unable to create the private file");
+
+    // Safe to use unwrap() because of the requirement
+    let private_key_arg = matches.get_one::<PathBuf>("input").unwrap();
+    let mut file = File::open(private_key_arg)?;
+
+    // Load the the ECC key in-memory and parse it
+    let mut buf = Vec::new();
+    file.read_to_end(&mut buf)?;
+    let mut secret =
+        parse_openssl_25519_privkey(&buf).expect("[ERROR] Unable to read the private key");
+
+    // Derive the key along the path
+    let mut key_pair = None;
+    for path in matches
+        .get_many::<String>("path")
+        .expect("[ERROR] At least one path must be provided")
+    {
+        let mut csprng = ChaChaRng::from_seed(apply_derive(path, secret));
+
+        // Use the high-level API to avoid duplicating code from curve25519-parser in case of futur changes
+        key_pair =
+            Some(generate_keypair(&mut csprng).expect("Error while generating the key-pair"));
+        secret = parse_openssl_25519_privkey(&key_pair.as_ref().unwrap().private_der).unwrap();
+    }
+
+    // Safe to unwrap, there is at least one derivation path
+    let key_pair = key_pair.unwrap();
+
+    // Output the public key in PEM format, to ease integration in text based
+    // configs
+    output_pub
+        .write_all(key_pair.public_as_pem().as_bytes())
+        .expect("Error writing the public key");
+
+    // Output the private key in DER format, to avoid common mistakes
+    output_priv
+        .write_all(&key_pair.private_der)
+        .expect("Error writing the private key");
+    Ok(())
+}
+
 pub struct ArchiveInfoReader {
     /// MLA Archive format Reader
 
@@ -1095,6 +1160,35 @@ fn app() -> clap::Command {
                 )
         )
         .subcommand(
+            Command::new("keyderive")
+                .about(
+                    "Derive a new public/private keypair from an existing one and a public path, in OpenSSL Ed25519 format, to be used by mlar",
+                )
+                .arg(
+                    Arg::new("input")
+                        .help("Input private key file")
+                        .num_args(1)
+                        .value_parser(value_parser!(PathBuf))
+                        .required(true)
+                )
+                .arg(
+                    Arg::new("output")
+                        .help("Output file for the private key. The public key is in {output}.pub")
+                        .num_args(1)
+                        .value_parser(value_parser!(PathBuf))
+                        .required(true)
+                )
+                .arg(
+                    Arg::new("path")
+                    .help("Public derivation path")
+                    .long("path")
+                    .short('p')
+                    .num_args(1)
+                    .action(ArgAction::Append)
+                    .value_parser(value_parser!(String))
+                )
+        )
+        .subcommand(
             Command::new("info")
                 .about("Get info on a MLA Archive")
                 .args(&input_args)
@@ -1130,6 +1224,8 @@ fn main() {
         convert(matches)
     } else if let Some(matches) = matches.subcommand_matches("keygen") {
         keygen(matches)
+    } else if let Some(matches) = matches.subcommand_matches("keyderive") {
+        keyderive(matches)
     } else if let Some(matches) = matches.subcommand_matches("info") {
         info(matches)
     } else {

--- a/mlar/tests/integration.rs
+++ b/mlar/tests/integration.rs
@@ -5,7 +5,7 @@ use rand::distributions::{Alphanumeric, Distribution, Standard};
 use rand::rngs::StdRng;
 use rand::SeedableRng;
 use std::collections::{HashMap, HashSet};
-use std::fs::{metadata, read_dir, File};
+use std::fs::{self, metadata, read_dir, File};
 use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
 use tar::Archive;
@@ -1038,6 +1038,114 @@ fn test_keygen_seed() {
     assert_eq!(pkey_testseed, PRIVATE_KEY_TESTSEED2);
 
     assert_ne!(PRIVATE_KEY_TESTSEED, PRIVATE_KEY_TESTSEED2);
+}
+
+#[test]
+fn test_keyderive() {
+    /*
+    key_parent
+    ├──["Child 1"]── key_child1
+    │   └──["Child 1"]── key_child1_child1
+    └──["Child 2"]── key_child2
+     */
+    let output_dir = TempDir::new().unwrap();
+    let key_parent = output_dir.path().join("key_parent");
+    let key_child1 = output_dir.path().join("key_child1");
+    let key_child2 = output_dir.path().join("key_child2");
+    let key_child1_child1 = output_dir.path().join("key_child1_child1");
+
+    //---------------- SETUP: Create and fill `keys` --------------
+    struct Keys {
+        parent: Vec<u8>,
+        child1: Vec<u8>,
+        child2: Vec<u8>,
+        child1child1: Vec<u8>,
+    }
+    let mut keys = Keys {
+        parent: vec![],
+        child1: vec![],
+        child2: vec![],
+        child1child1: vec![],
+    };
+
+    // `mlar keygen tempdir/key_parent`
+    let mut cmd = Command::cargo_bin(UTIL).unwrap();
+    cmd.arg("keygen").arg(&key_parent);
+    cmd.assert().success();
+
+    keys.parent = fs::read(&key_parent).unwrap();
+
+    // `mlar keyderive tempdir/key_parent tempdir/key_child1 --path "Child 1"`
+    let mut cmd = Command::cargo_bin(UTIL).unwrap();
+    cmd.arg("keyderive")
+        .arg(&key_parent)
+        .arg(&key_child1)
+        .arg("-p")
+        .arg("Child 1");
+    cmd.assert().success();
+
+    keys.child1 = fs::read(&key_child1).unwrap();
+
+    // `mlar keyderive tempdir/key_parent tempdir/key_child2 --path "Child 2"`
+    let mut cmd = Command::cargo_bin(UTIL).unwrap();
+    cmd.arg("keyderive")
+        .arg(&key_parent)
+        .arg(&key_child2)
+        .arg("-p")
+        .arg("Child 2");
+    cmd.assert().success();
+
+    keys.child2 = fs::read(&key_child2).unwrap();
+
+    // `mlar keyderive tempdir/key_child1 tempdir/key_child1_child1 --path "Child 1"`
+    let mut cmd = Command::cargo_bin(UTIL).unwrap();
+    cmd.arg("keyderive")
+        .arg(&key_child1)
+        .arg(&key_child1_child1)
+        .arg("-p")
+        .arg("Child 1");
+    cmd.assert().success();
+
+    keys.child1child1 = fs::read(&key_child1_child1).unwrap();
+
+    //---------------- END OF SETUP -----------------
+
+    // Assert all keys are different
+    let v: HashSet<_> = vec![&keys.parent, &keys.child1, &keys.child2, &keys.child1child1]
+        .iter()
+        .cloned()
+        .collect();
+    assert_eq!(v.len(), 4);
+
+    // Ensure path is deterministic
+
+    let key_tmp = output_dir.path().join("key_tmp");
+    // `mlar keyderive tempdir/key_parent tempdir/key_tmp --path "Child 2"`
+    let mut cmd = Command::cargo_bin(UTIL).unwrap();
+    cmd.arg("keyderive")
+        .arg(&key_parent)
+        .arg(&key_tmp)
+        .arg("-p")
+        .arg("Child 2");
+    cmd.assert().success();
+
+    assert_eq!(keys.child2, fs::read(&key_tmp).unwrap());
+
+    // Ensure path is transitive
+
+    let key_tmp2 = output_dir.path().join("key_tmp2");
+    // `mlar keyderive tempdir/key_parent tempdir/key_tmp2 --path "Child 1" --path "Child 1"`
+    let mut cmd = Command::cargo_bin(UTIL).unwrap();
+    cmd.arg("keyderive")
+        .arg(&key_parent)
+        .arg(&key_tmp2)
+        .arg("-p")
+        .arg("Child 1")
+        .arg("-p")
+        .arg("Child 1");
+    cmd.assert().success();
+
+    assert_eq!(keys.child1child1, fs::read(&key_tmp2).unwrap());
 }
 
 #[test]

--- a/mlar/tests/integration.rs
+++ b/mlar/tests/integration.rs
@@ -995,6 +995,51 @@ fn test_keygen() {
     assert.success().stdout(file_list);
 }
 
+const PRIVATE_KEY_TESTSEED: [u8; 48] = [
+    48, 46, 2, 1, 0, 48, 5, 6, 3, 43, 101, 110, 4, 34, 4, 32, 94, 121, 194, 104, 155, 90, 60, 64,
+    82, 240, 66, 106, 58, 170, 219, 60, 118, 22, 29, 161, 99, 243, 195, 174, 36, 134, 238, 189,
+    226, 45, 50, 34,
+];
+
+const PRIVATE_KEY_TESTSEED2: [u8; 48] = [
+    48, 46, 2, 1, 0, 48, 5, 6, 3, 43, 101, 110, 4, 34, 4, 32, 149, 139, 7, 71, 128, 28, 248, 2,
+    227, 242, 22, 225, 219, 80, 100, 43, 179, 186, 25, 174, 243, 30, 246, 96, 133, 12, 240, 86, 17,
+    254, 140, 0,
+];
+
+#[test]
+fn test_keygen_seed() {
+    // Gen deterministic keypairs
+    let output_dir = TempDir::new().unwrap();
+    let base_name = output_dir.path().join("key");
+
+    // `mlar keygen tempdir/key -s TESTSEED`
+    let mut cmd = Command::cargo_bin(UTIL).unwrap();
+    cmd.arg("keygen").arg(&base_name).arg("-s").arg("TESTSEED");
+    cmd.assert().success();
+
+    let mut pkey_testseed = vec![];
+    File::open(&base_name)
+        .unwrap()
+        .read_to_end(&mut pkey_testseed)
+        .unwrap();
+    assert_eq!(pkey_testseed, PRIVATE_KEY_TESTSEED);
+
+    // `mlar keygen tempdir/key -s TESTSEED2`
+    let mut cmd = Command::cargo_bin(UTIL).unwrap();
+    cmd.arg("keygen").arg(&base_name).arg("-s").arg("TESTSEED2");
+    cmd.assert().success();
+
+    let mut pkey_testseed = vec![];
+    File::open(&base_name)
+        .unwrap()
+        .read_to_end(&mut pkey_testseed)
+        .unwrap();
+    assert_eq!(pkey_testseed, PRIVATE_KEY_TESTSEED2);
+
+    assert_ne!(PRIVATE_KEY_TESTSEED, PRIVATE_KEY_TESTSEED2);
+}
+
 #[test]
 fn test_verbose_info() {
     let ecc_public = Path::new("../samples/test_x25519_pub.pem");


### PR DESCRIPTION
Fix #154 

This PR:

- add a `--seed` option to `mlar keygen`  to deterministically generate keypair
- add a `mlar keyderive` to derive key along a hierarchical path, ie. to build key-tree
- add their associated tests
- document their internals in the README's FAQ

Notes on the implementation (the algorithm detail is in the PR):

- the `seed` is a string used to seed the ChaCha-20 PRNG already used to generate keypairs. A SHA-512 is used to convert the input seed to the expected format. Only 32 bytes is needed, but using this scheme, extra bytes are provided for a potential future use
- the derivation is made using `HKDF` with the same idea: the HKDF function is used to create a seed, feed in the ChaCha-20 to create a new keypair. The ChaCha-20 might not be useful here, but it adds a layer of irreversibility and simplifies the implementation 

