### PR TITLE
Update brotli-decompressor

### DIFF
--- a/mla/Cargo.toml
+++ b/mla/Cargo.toml
@@ -32,7 +32,6 @@ x25519-dalek = { version = "1", default-features = false}
 hkdf = { version = "0", default-features = false}
 sha2 = { version = "0", default-features = false}
 zeroize = { version = "1", default-features = false}
-brotli-decompressor = { version = "=2.3.3" }
 
 
 [dev-dependencies]

--- a/mla/src/layers/compress.rs
+++ b/mla/src/layers/compress.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 use bincode::Options;
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 use serde::{Deserialize, Serialize};
@@ -73,6 +75,17 @@ enum CompressionLayerReaderState<R: Read> {
     /// Empty is a placeholder to allow state replacement
     Empty,
 }
+
+impl<R: Read> fmt::Debug for CompressionLayerReaderState<R> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            CompressionLayerReaderState::Ready(_inner) => write!(f, "Ready"),
+            CompressionLayerReaderState::InData { .. } => write!(f, "InData"),
+            CompressionLayerReaderState::Empty => write!(f, "Empty")
+        }
+    }
+}
+
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct SizesInfo {


### PR DESCRIPTION
Fix #146 
Fix #147 

This PR:

- bump `brotli-decompressor` from 2.3.3 to 2.3.4
- fix the breaking change in its API use, as explain in #146 
- add a regression test to detect this case, as explain in #146 