### PR TITLE
Repair: remove the COMPRESS bottleneck

### DIFF
--- a/mla/src/layers/compress.rs
+++ b/mla/src/layers/compress.rs
@@ -843,7 +843,7 @@ impl<'a, R: 'a + Read> Read for CompressionLayerFailSafeReader<'a, R> {
                         }
                         // There is still data in the cache to read
                         // Will fail and return the error on the next .read()
-                }
+                    }
                 }
 
                 // Number of byte available in the source
@@ -1146,8 +1146,8 @@ mod tests {
                 .unwrap(),
             );
             let mut buf = Vec::new();
-            // This may ends with an error, when we start reading the footer (invalid for decompression)
-            decomp.read_to_end(&mut buf).unwrap();
+            // This must ends with an error, when we start reading the footer (invalid for decompression)
+            decomp.read_to_end(&mut buf).unwrap_err();
             println!(
                 "Compression / Decompression (fail-safe): {} us for {} bytes ({} compressed)",
                 now.elapsed().as_micros(),

--- a/mla/src/layers/compress.rs
+++ b/mla/src/layers/compress.rs
@@ -2,6 +2,8 @@ use std::fmt;
 use std::io::{self, Read, Seek, SeekFrom, Take, Write};
 
 use bincode::Options;
+use brotli::writer::StandardAlloc;
+use brotli::BrotliState;
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 use serde::{Deserialize, Serialize};
 
@@ -675,14 +677,78 @@ impl<'a, W: 'a + InnerWriterTrait> Write for CompressionLayerWriter<'a, W> {
 
 // ---------- Fail-Safe Reader ----------
 
+/// Internal state for the `CompressionLayerFailSafeReader`
+enum CompressionLayerFailSafeReaderState<R: Read> {
+    /// Ready contains the real inner destination
+    /// Only used for the initialization
+    Ready(R),
+    /// Inside a decompression stream
+    InData {
+        /// While decompressing, one doesn't know in advance the number of compressed bytes
+        /// As a result, the following is done:
+        /// 1. read from the source inside a buffer
+        /// 2. decompress the data from the buffer
+        ///     - if there is still data to decompress, go to 1.
+        ///     - if this is the end of the stream, continue to 3.
+        /// 3. the decompressor may have read too many byte, ie. `[end of stream n-1][start of stream n]`
+        ///                                                                          ^                 ^
+        ///                                                                     input_offset    last read position
+        /// 4. rewind, using the cache, to `input_offset`
+        ///
+        /// A cache must be used, as the source is `Read` but not `Seek`.
+        /// `input_offset` is guaranted to be in the cache because it must be in the decompressor working buffer,
+        /// and the working buffer is contained in the cache (in the worst case, it is the whole cache)
+        ///
+        /// Cache management:
+        /// ```ascii
+        ///                cache_filled_offset
+        ///                        v
+        /// cache: [................    ]
+        ///            ^
+        ///        read_offset
+        /// ```
+        /// Data read from the source, not yet used
+        /// Invariant:
+        ///     - cache.len() == FAIL_SAFE_BUFFER_SIZE (cache always allocated)
+        cache: Vec<u8>,
+        /// Bytes valid in the cache : [0..`cache_filled_offset`[ (0 -> no valid data)
+        cache_filled_offset: usize,
+        /// Next offset to read from the cache
+        /// Invariant:
+        ///     - `read_offset` <= `cache_filled_offset`
+        read_offset: usize,
+        /// Internal decompressor state
+        state: Box<BrotliState<StandardAlloc, StandardAlloc, StandardAlloc>>,
+        /// Number of bytes decompressed and returned for the current stream
+        uncompressed_read: u32,
+        /// Inner layer (data source)
+        inner: R,
+    },
+    /// Empty is a placeholder to allow state replacement
+    Empty,
+}
+
+impl<R: Read> CompressionLayerFailSafeReaderState<R> {
+    fn into_inner(self) -> R {
+        match self {
+            CompressionLayerFailSafeReaderState::Ready(inner) => inner,
+            CompressionLayerFailSafeReaderState::InData { inner, .. } => inner,
+            // `panic!` explicitly called to avoid propagating an error which
+            // must never happens (ie, calling `into_inner` in an inconsistent
+            // internal state)
+            _ => panic!("[Reader] Empty type to inner is impossible"),
+        }
+    }
+}
+
 pub struct CompressionLayerFailSafeReader<'a, R: 'a + Read> {
-    state: CompressionLayerReaderState<Box<dyn 'a + LayerFailSafeReader<'a, R>>>,
+    state: CompressionLayerFailSafeReaderState<Box<dyn 'a + LayerFailSafeReader<'a, R>>>,
 }
 
 impl<'a, R: 'a + Read> CompressionLayerFailSafeReader<'a, R> {
     pub fn new(inner: Box<dyn 'a + LayerFailSafeReader<'a, R>>) -> Result<Self, Error> {
         Ok(Self {
-            state: CompressionLayerReaderState::Ready(inner),
+            state: CompressionLayerFailSafeReaderState::Ready(inner),
         })
     }
 }
@@ -697,6 +763,8 @@ impl<'a, R: 'a + Read> LayerFailSafeReader<'a, R> for CompressionLayerFailSafeRe
     }
 }
 
+const FAIL_SAFE_BUFFER_SIZE: usize = 4096;
+
 impl<'a, R: 'a + Read> Read for CompressionLayerFailSafeReader<'a, R> {
     /// This `read` is expected to end by failing
     ///
@@ -706,62 +774,153 @@ impl<'a, R: 'a + Read> Read for CompressionLayerFailSafeReader<'a, R> {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         // Use this mem::replace trick to be able to get back the compressor
         // inner and freely move from CompressionLayerReaderState to others
-        let old_state = std::mem::replace(&mut self.state, CompressionLayerReaderState::Empty);
+        let old_state =
+            std::mem::replace(&mut self.state, CompressionLayerFailSafeReaderState::Empty);
         match old_state {
-            CompressionLayerReaderState::Ready(inner) => {
-                // Default values, for "repair" mode
-
-                // Use a block size of `1` to ensure the decompression
-                // will stop on the first byte of the next CompressionBlock.
-                // This is slower, but we don't have index, and
-                // therefore we don't know the compressed block size
-                // Take more than the maximum number of compressed byte (as the real number is unknown)
-                // to comply with the CompressionLayerReaderState type
-                let decompressor = Box::new(brotli::Decompressor::new(
-                    inner.take(2 * UNCOMPRESSED_DATA_SIZE as u64),
-                    1,
-                ));
-                self.state = CompressionLayerReaderState::InData {
-                    read: 0,
-                    // Default values, for "repair" mode
-                    uncompressed_size: UNCOMPRESSED_DATA_SIZE,
-                    decompressor,
+            CompressionLayerFailSafeReaderState::Ready(inner) => {
+                self.state = CompressionLayerFailSafeReaderState::InData {
+                    cache: vec![0u8; FAIL_SAFE_BUFFER_SIZE],
+                    read_offset: 0,
+                    cache_filled_offset: 0,
+                    state: Box::new(BrotliState::new(
+                        StandardAlloc::default(),
+                        StandardAlloc::default(),
+                        StandardAlloc::default(),
+                    )),
+                    uncompressed_read: 0,
+                    inner,
                 };
                 self.read(buf)
             }
-            CompressionLayerReaderState::InData {
-                read,
-                uncompressed_size,
-                mut decompressor,
+            CompressionLayerFailSafeReaderState::InData {
+                mut cache,
+                mut read_offset,
+                mut cache_filled_offset,
+                mut state,
+                mut uncompressed_read,
+                mut inner,
             } => {
-                if read > uncompressed_size {
+                if uncompressed_read > UNCOMPRESSED_DATA_SIZE {
                     return Err(Error::WrongReaderState(
                         "[Compress FailSafe Layer] Too much data read".to_string(),
                     )
                     .into());
                 }
-                if read == uncompressed_size {
-                    // Consume the rest of the current decompressor. Due to the
-                    // brotli implementation, a few bytes might remains, even if
-                    // we already obtain the expected number of bytes. Thanks to
-                    // the brotli format, the decompressor is able to stop at
-                    // the end of the current block.
-                    io::copy(&mut decompressor, &mut io::sink())?;
-                    // Start a new block, fill it with new values
-                    self.state =
-                        CompressionLayerReaderState::Ready(decompressor.into_inner().into_inner());
-                    return self.read(buf);
+
+                if read_offset == cache_filled_offset
+                    && cache_filled_offset == FAIL_SAFE_BUFFER_SIZE
+                {
+                    // Cache is full and there is no more data to read from
+                    // -> cache must be reset
+                    cache.fill(0);
+                    cache_filled_offset = 0;
+                    read_offset = 0;
                 }
-                let size = std::cmp::min((uncompressed_size - read) as usize, buf.len());
-                let read_add = decompressor.read(&mut buf[..size])?;
-                self.state = CompressionLayerReaderState::InData {
-                    read: read + read_add as u32,
-                    uncompressed_size,
-                    decompressor,
+
+                // Try to fill the cache from the inner source
+                match inner.read(&mut cache[cache_filled_offset..]) {
+                    Ok(read) => {
+                        if read == 0 && read_offset == cache_filled_offset {
+                            // No more data from inner and the cache has been fully read
+                            // -> return either an error or Ok(0)
+                            if uncompressed_read > 0 {
+                                // Inside a stream and no more data available
+                                return Err(io::Error::new(
+                                    io::ErrorKind::UnexpectedEof,
+                                    "No more data from the inner layer",
+                                ));
+                            } else {
+                                // No more data available but not in a stream
+                                return Ok(0);
+                            }
+                        }
+                        cache_filled_offset += read;
+                    }
+                    error => {
+                        if read_offset == cache_filled_offset {
+                            // No more data in the cache
+                            return error;
+                        }
+                        // There is still data in the cache to read
+                        // Will fail and return the error on the next .read()
+                }
+                }
+
+                // Number of byte available in the source
+                let mut available_in = cache_filled_offset - read_offset;
+                // IN: Offset in the source
+                // OUT: Offset in the source after the decompression pass
+                let mut input_offset = 0;
+                // Available spaces in the output
+                let mut available_out = std::cmp::min(
+                    buf.len(),
+                    (UNCOMPRESSED_DATA_SIZE - uncompressed_read) as usize,
+                );
+                // IN: Offset in the output
+                // OUT: number of bytes written in the output
+                let mut output_offset = 0;
+                // OUT: total number of byte written for the current stream (cumulative)
+                let mut written = 0;
+
+                let ret = match brotli::BrotliDecompressStream(
+                    &mut available_in,
+                    &mut input_offset,
+                    &cache[read_offset..cache_filled_offset],
+                    &mut available_out,
+                    &mut output_offset,
+                    buf,
+                    &mut written,
+                    &mut state,
+                ) {
+                    brotli::BrotliResult::ResultSuccess => {
+                        // End of stream reached
+
+                        // Rewind the cache to the actual start of the new block
+                        // input_offset \in [0; cache_filled_offset - read_offset[
+                        read_offset += input_offset;
+
+                        // Reset others
+                        state = Box::new(BrotliState::new(
+                            StandardAlloc::default(),
+                            StandardAlloc::default(),
+                            StandardAlloc::default(),
+                        ));
+                        uncompressed_read = 0;
+
+                        Ok(output_offset)
+                    }
+                    brotli::BrotliResult::NeedsMoreInput => {
+                        // Bytes may have been read and produced
+                        read_offset += input_offset;
+                        uncompressed_read += output_offset as u32;
+
+                        Ok(output_offset)
+                    }
+                    brotli::BrotliResult::NeedsMoreOutput => {
+                        // Bytes may have been read and produced
+                        read_offset += input_offset;
+                        uncompressed_read += output_offset as u32;
+
+                        Ok(output_offset)
+                    }
+                    brotli::BrotliResult::ResultFailure => Err(io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        "Invalid Data while decompressing",
+                    )),
                 };
-                Ok(read_add)
+
+                self.state = CompressionLayerFailSafeReaderState::InData {
+                    cache,
+                    cache_filled_offset,
+                    read_offset,
+                    state,
+                    uncompressed_read,
+                    inner,
+                };
+
+                ret
             }
-            CompressionLayerReaderState::Empty => Err(Error::WrongReaderState(
+            CompressionLayerFailSafeReaderState::Empty => Err(Error::WrongReaderState(
                 "[Compression Layer] Should never happens, unless an error already occurs before"
                     .to_string(),
             )

--- a/mla/src/layers/compress.rs
+++ b/mla/src/layers/compress.rs
@@ -1044,7 +1044,7 @@ mod tests {
         match brotli::BrotliDecompressStream(
             &mut available_in,
             &mut input_offset,
-            &src.get_ref(),
+            src.get_ref(),
             &mut available_out,
             &mut output_offset,
             &mut buf,


### PR DESCRIPTION
Fix #157 

This PR removes the bottleneck of the "compress" layer (as described in #157).

The approach used is the following:

- `brotli::BrotliDecompressStream` is used instead of `brotli::Decompressor`, giving more control on what is happening
- using the information from this more detailed API, the last relevant input byte of the decompressor for a given stream can be retrieved. As a result, one known where to start the following decompression stream
- as the inner layer is not `Seek`, a cache mechanism is used. The implementation detail is in `CompressionLayerFailSafeReaderState` comments, and reproduced below:

----

While decompressing, one doesn't know in advance the number of compressed bytes
As a result, the following is done:

1. read from the source inside a buffer
2. decompress the data from the buffer
    - if there is still data to decompress, go to 1.
    - if this is the end of the stream, continue to 3.
3. the decompressor may have read too many byte, ie. 
```
[end of stream n-1][start of stream n]
                   ^                 ^
              input_offset    last read position
```
4. rewind, using the cache, to `input_offset`

A cache must be used, as the source is `Read` but not `Seek`.
`input_offset` is guaranted to be in the cache because it must be in the decompressor working buffer,
and the working buffer is contained in the cache (in the worst case, it is the whole cache)

Cache management:
```ascii
               cache_filled_offset
                       v
cache: [................    ]
           ^
       read_offset
```

----

From the benchmark, we can observe an approximately x40 speed-up when it concerns the COMPRESS layer:

|group                                                                 |post-fix                               |pre-fix                            |
|----------------------------------------------------------------------|---------------------------------------|-----------------------------------|
|failsafe_multiple_layers_repair/Layers(0x0)/4194304                   |1.00     76.4±3.69ms    52.4 MB/sec    |1.01     77.2±2.07ms    51.8 MB/sec|
|failsafe_multiple_layers_repair/Layers(COMPRESS)/4194304              |1.00    133.4±1.61ms    **30.0 MB/sec**    |42.59      5.7±0.34s   720.8 KB/sec|
|failsafe_multiple_layers_repair/Layers(ENCRYPT \| COMPRESS)/4194304    |1.00    151.0±4.56ms    **26.5 MB/sec**    |38.06      5.7±0.03s   712.6 KB/sec|
|failsafe_multiple_layers_repair/Layers(ENCRYPT)/4194304               |1.02    101.5±0.92ms    39.4 MB/sec    |1.00     99.2±0.30ms    40.3 MB/sec|
