### PR TITLE
CI: windows-bindings: force 1.69 due to cargo regression in 1.70

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -107,7 +107,9 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions-rs/toolchain@v1
       with:
-        toolchain: stable
+        # Avoid a regression of Cargo, breaking at link time
+        toolchain: 1.69
+        default: true
         target: ${{ matrix.target }}
     - uses: microsoft/setup-msbuild@v1.0.2
     - name: Compile C/CPP bindings test program for Windows


### PR DESCRIPTION
Temporary fix for the CI: bindings tests no more compile with cargo 1.70.
It seems to be a regression in the way cargo handle paths in a workspace environment.

For now, force the toolchain version to 1.69 only in the Windows' binding tests.

