### PR TITLE
Diverse clippy fixes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -132,7 +132,7 @@ jobs:
       - name: Install cargo-afl binary crate
         uses: actions-rs/install@v0.1
         with:
-          crate: afl
+          crate: cargo-afl
           version: latest
           use-tool-cache: true
       - name: Test AFL build
@@ -173,7 +173,7 @@ jobs:
       - name: Install cargo-afl binary crate
         uses: actions-rs/install@v0.1
         with:
-          crate: afl
+          crate: cargo-afl
           version: latest
           use-tool-cache: true
       - uses: actions-rs/cargo@v1

--- a/bindings/C/src/lib.rs
+++ b/bindings/C/src/lib.rs
@@ -221,7 +221,7 @@ pub extern "C" fn mla_config_add_public_keys(
     let mut config = unsafe { Box::from_raw(config as *mut ArchiveWriterConfig) };
 
     // Create a slice from the NULL-terminated string
-    let public_keys = unsafe { CStr::from_ptr(public_keys as *const i8) }.to_bytes();
+    let public_keys = unsafe { CStr::from_ptr(public_keys) }.to_bytes();
     // Parse as OpenSSL Ed25519 public key(s)
     let res = match parse_openssl_25519_pubkeys_pem_many(public_keys) {
         Ok(v) if !v.is_empty() => {
@@ -290,7 +290,7 @@ pub extern "C" fn mla_reader_config_add_private_key(
     let mut private_keys = Vec::new();
 
     // Create a slice from the NULL-terminated string
-    let private_key = unsafe { CStr::from_ptr(private_key as *const i8) }.to_bytes();
+    let private_key = unsafe { CStr::from_ptr(private_key) }.to_bytes();
     // Parse as OpenSSL Ed25519 private key(s)
     let res = match parse_openssl_25519_privkey(private_key) {
         Ok(v) => {

--- a/mla/src/layers/compress.rs
+++ b/mla/src/layers/compress.rs
@@ -1094,7 +1094,7 @@ mod tests {
     fn compress_layer() {
         // Compress then decompress with dedicated Layer structs
 
-        for data in vec![get_data(), get_uncompressable_data()] {
+        for data in [get_data(), get_uncompressable_data()] {
             let bytes = data.as_slice();
 
             let file = Vec::new();
@@ -1127,7 +1127,7 @@ mod tests {
     fn compress_failsafe_layer() {
         // Compress then decompress with Fail-Safe Layer structs
 
-        for data in vec![get_data(), get_uncompressable_data()] {
+        for data in [get_data(), get_uncompressable_data()] {
             let bytes = data.as_slice();
 
             let file = Vec::new();
@@ -1163,7 +1163,7 @@ mod tests {
     fn compress_failsafe_truncated() {
         // Compress then decompress with Fail-Safe Layer structs, while truncating the intermediate buffer
 
-        for data in vec![get_data(), get_uncompressable_data()] {
+        for data in [get_data(), get_uncompressable_data()] {
             let bytes = data.as_slice();
 
             let file = Vec::new();
@@ -1236,7 +1236,7 @@ mod tests {
 
     #[test]
     fn seek_with_footer() {
-        for data in vec![get_data(), get_uncompressable_data()] {
+        for data in [get_data(), get_uncompressable_data()] {
             let bytes = data.as_slice();
 
             let file = Vec::new();

--- a/mlar/tests/integration.rs
+++ b/mlar/tests/integration.rs
@@ -431,11 +431,11 @@ fn test_truncated_repair_list_tar() {
 fn test_multiple_keys() {
     // Key parsing is common for each subcommands, so test only one: `list`
     let mlar_file = NamedTempFile::new("output.mla").unwrap();
-    let ecc_publics = vec![
+    let ecc_publics = [
         Path::new("../samples/test_x25519_pub.pem"),
         Path::new("../samples/test_x25519_3_pub.pem"),
     ];
-    let ecc_privates = vec![
+    let ecc_privates = [
         Path::new("../samples/test_x25519.pem"),
         Path::new("../samples/test_x25519_2.pem"),
     ];
@@ -545,7 +545,7 @@ fn test_multiple_compression_level() {
     assert!(q5_size < q0_size);
 
     // Ensure files are correct
-    for (src, tar_name) in vec![(mlar_file_q0, &tar_file_q0), (mlar_file_q5, &tar_file_q5)] {
+    for (src, tar_name) in [(mlar_file_q0, &tar_file_q0), (mlar_file_q5, &tar_file_q5)] {
         // `mlar to-tar -i {src} -o {tar_name}`
         let mut cmd = Command::cargo_bin(UTIL).unwrap();
         cmd.arg("to-tar")
@@ -1111,7 +1111,7 @@ fn test_keyderive() {
     //---------------- END OF SETUP -----------------
 
     // Assert all keys are different
-    let v: HashSet<_> = vec![&keys.parent, &keys.child1, &keys.child2, &keys.child1child1]
+    let v: HashSet<_> = [&keys.parent, &keys.child1, &keys.child2, &keys.child1child1]
         .iter()
         .cloned()
         .collect();


### PR DESCRIPTION
- clippy::unnecessary_cast
- AFL 0.14 split `afl` and `cargo-afl`, breaking the `clippy` CI workflow (and the `afl` one)
- clippy::useless_vec (in tests)