### PR TITLE
CI: test for publishing state

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -180,3 +180,19 @@ jobs:
         with:
           command: clippy
           args: --all-targets -- -D warnings
+
+  publish-dry-run:
+      runs-on: ubuntu-latest
+
+      steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+      - name: Dry-run publish curve25519-parser
+        run: cd curve25519-parser && cargo publish --dry-run
+      - name: Dry-run publish mla
+        run: cd mla && cargo publish --dry-run
+      - name: Dry-run publish mlar
+        run: cd mlar && cargo publish --dry-run
+      


### PR DESCRIPTION
Add a CI test for `cargo publish`.
Notably, this command can catch weird state of internal features, or missing feature activation.

For instance, if an `mla` dependency enables a feature which is required by `mla` but not explicitly imported by it, `cargo build` and `cargo tests` will happily work. But `cargo publish` will spot the problem. 