### PR TITLE
Homogeneise `mlar extract -v` output

### DIFF
--- a/mlar/src/main.rs
+++ b/mlar/src/main.rs
@@ -454,6 +454,10 @@ struct FileWriter<'a> {
     /// Reference on the cache
     // A `Mutex` is used instead of a `RefCell` as `FileWriter` can be `Send`
     cache: &'a Mutex<LruCache<PathBuf, File>>,
+    /// Is verbose mode enabled
+    verbose: bool,
+    /// Filename in the archive
+    fname: &'a str
 }
 
 /// Max number of fd simultaneously opened
@@ -466,6 +470,9 @@ impl<'a> Write for FileWriter<'a> {
         if !cache.contains(&self.path) {
             let file = fs::OpenOptions::new().append(true).open(&self.path)?;
             cache.put(self.path.clone(), file);
+            if self.verbose {
+                println!("{}", self.fname);
+            }
         }
         // Safe to `unwrap` here cause we ensure the element is in the cache (mono-threaded)
         let file = cache.get_mut(&self.path).unwrap();
@@ -603,6 +610,8 @@ fn extract(matches: &ArgMatches) -> Result<(), MlarError> {
                         FileWriter {
                             path,
                             cache: &cache,
+                            verbose,
+                            fname
                         },
                     );
                 }

--- a/mlar/src/main.rs
+++ b/mlar/src/main.rs
@@ -457,7 +457,7 @@ struct FileWriter<'a> {
     /// Is verbose mode enabled
     verbose: bool,
     /// Filename in the archive
-    fname: &'a str
+    fname: &'a str,
 }
 
 /// Max number of fd simultaneously opened
@@ -611,7 +611,7 @@ fn extract(matches: &ArgMatches) -> Result<(), MlarError> {
                             path,
                             cache: &cache,
                             verbose,
-                            fname
+                            fname,
                         },
                     );
                 }

--- a/mlar/tests/integration.rs
+++ b/mlar/tests/integration.rs
@@ -856,9 +856,7 @@ fn test_extract() {
         "Extracting the whole archive using a linear extraction\n{}",
         file_list
     );
-    assert
-        .success()
-        .stdout(expected_output);
+    assert.success().stdout(expected_output);
 
     ensure_directory_content(output_dir.path(), &testfs.files);
 
@@ -1343,9 +1341,7 @@ fn test_extract_lot_files() {
         "Extracting the whole archive using a linear extraction\n{}",
         file_list
     );
-    assert
-        .success()
-        .stdout(expected_output);
+    assert.success().stdout(expected_output);
 
     ensure_directory_content(output_dir.path(), &testfs.files);
 

--- a/mlar/tests/integration.rs
+++ b/mlar/tests/integration.rs
@@ -834,7 +834,7 @@ fn test_extract() {
 
     println!("{cmd:?}");
     let assert = cmd.assert();
-    assert.success().stdout(file_list);
+    assert.success().stdout(file_list.clone());
 
     ensure_directory_content(output_dir.path(), &testfs.files);
 
@@ -852,9 +852,13 @@ fn test_extract() {
 
     println!("{cmd:?}");
     let assert = cmd.assert();
+    let expected_output = format!(
+        "Extracting the whole archive using a linear extraction\n{}",
+        file_list
+    );
     assert
         .success()
-        .stdout("Extracting the whole archive using a linear extraction\n");
+        .stdout(expected_output);
 
     ensure_directory_content(output_dir.path(), &testfs.files);
 
@@ -1317,7 +1321,7 @@ fn test_extract_lot_files() {
 
     println!("{:?}", cmd);
     let assert = cmd.assert();
-    assert.success().stdout(file_list);
+    assert.success().stdout(file_list.clone());
 
     ensure_directory_content(output_dir.path(), &testfs.files);
 
@@ -1335,9 +1339,13 @@ fn test_extract_lot_files() {
 
     println!("{:?}", cmd);
     let assert = cmd.assert();
+    let expected_output = format!(
+        "Extracting the whole archive using a linear extraction\n{}",
+        file_list
+    );
     assert
         .success()
-        .stdout("Extracting the whole archive using a linear extraction\n");
+        .stdout(expected_output);
 
     ensure_directory_content(output_dir.path(), &testfs.files);
 


### PR DESCRIPTION
Outputs were inconsistent if linear extraction was or wasn't used.