### PR TITLE
When "send" feature is enabled, make Readers `Send` too

### DIFF
--- a/mla/src/helpers.rs
+++ b/mla/src/helpers.rs
@@ -1,3 +1,5 @@
+use crate::layers::traits::InnerReaderTrait;
+
 use super::layers::traits::InnerWriterTrait;
 /// Helpers for common operation with MLA Archives
 use super::{ArchiveFileBlock, ArchiveFileID, ArchiveReader, ArchiveWriter, Error};
@@ -19,7 +21,7 @@ use std::io::{self, Read, Seek, Write};
 /// encryption tag).
 /// Linear extraction avoids these costs by reading once and only once each byte,
 /// and by reducing the amount of seeks.
-pub fn linear_extract<W1: InnerWriterTrait, R: Read + Seek, S: BuildHasher>(
+pub fn linear_extract<W1: InnerWriterTrait, R: InnerReaderTrait, S: BuildHasher>(
     archive: &mut ArchiveReader<R>,
     export: &mut HashMap<&String, W1, S>,
 ) -> Result<(), Error> {

--- a/mla/src/layers/compress.rs
+++ b/mla/src/layers/compress.rs
@@ -15,6 +15,8 @@ use crate::{Error, BINCODE_MAX_DESERIALIZE};
 use crate::config::{ArchiveWriterConfig, ConfigResult};
 use crate::errors::ConfigError;
 
+use super::traits::InnerReaderTrait;
+
 // ---------- Config ----------
 
 /// A bigger value means a better compression ratio, less indexes to save (in
@@ -292,7 +294,7 @@ impl<'a, R: 'a + Read> CompressionLayerReader<'a, R> {
     }
 }
 
-impl<'a, R: 'a + Read + Seek> LayerReader<'a, R> for CompressionLayerReader<'a, R> {
+impl<'a, R: 'a + InnerReaderTrait> LayerReader<'a, R> for CompressionLayerReader<'a, R> {
     fn into_inner(self) -> Option<Box<dyn 'a + LayerReader<'a, R>>> {
         Some(self.state.into_inner())
     }

--- a/mla/src/layers/encrypt.rs
+++ b/mla/src/layers/encrypt.rs
@@ -16,6 +16,8 @@ use x25519_dalek::{PublicKey, StaticSecret};
 
 use serde::{Deserialize, Serialize};
 
+use super::traits::InnerReaderTrait;
+
 const CIPHER_BUF_SIZE: u64 = 4096;
 // This is the size of the nonce taken as input
 const NONCE_SIZE: usize = 8;
@@ -342,7 +344,7 @@ impl<'a, R: 'a + Read + Seek> EncryptionLayerReader<'a, R> {
     }
 }
 
-impl<'a, R: 'a + Read + Seek> LayerReader<'a, R> for EncryptionLayerReader<'a, R> {
+impl<'a, R: 'a + InnerReaderTrait> LayerReader<'a, R> for EncryptionLayerReader<'a, R> {
     fn into_inner(self) -> Option<Box<dyn 'a + LayerReader<'a, R>>> {
         Some(self.inner)
     }

--- a/mla/src/layers/raw.rs
+++ b/mla/src/layers/raw.rs
@@ -6,6 +6,8 @@ use crate::layers::traits::{
 };
 use crate::Error;
 
+use super::traits::InnerReaderTrait;
+
 // ---------- Writer ----------
 
 /// Dummy layer, standing for the last layer (wrapping I/O)
@@ -49,13 +51,13 @@ impl<W: InnerWriterTrait> Write for RawLayerWriter<W> {
 // ---------- Reader ----------
 
 /// Dummy layer, standing for the last layer (wrapping I/O)
-pub struct RawLayerReader<R: Read + Seek> {
+pub struct RawLayerReader<R: InnerReaderTrait> {
     inner: R,
     // Offset to use in position
     offset_pos: u64,
 }
 
-impl<R: Read + Seek> RawLayerReader<R> {
+impl<R: InnerReaderTrait> RawLayerReader<R> {
     pub fn new(inner: R) -> Self {
         Self {
             inner,
@@ -70,7 +72,7 @@ impl<R: Read + Seek> RawLayerReader<R> {
     }
 }
 
-impl<'a, R: Read + Seek> LayerReader<'a, R> for RawLayerReader<R> {
+impl<'a, R: InnerReaderTrait> LayerReader<'a, R> for RawLayerReader<R> {
     fn into_inner(self) -> Option<Box<dyn 'a + LayerReader<'a, R>>> {
         None
     }
@@ -85,7 +87,7 @@ impl<'a, R: Read + Seek> LayerReader<'a, R> for RawLayerReader<R> {
     }
 }
 
-impl<R: Read + Seek> Seek for RawLayerReader<R> {
+impl<R: InnerReaderTrait> Seek for RawLayerReader<R> {
     /// Offer a position relatively to `self.offset_pos`
     fn seek(&mut self, ask_pos: SeekFrom) -> io::Result<u64> {
         match ask_pos {
@@ -115,7 +117,7 @@ impl<R: Read + Seek> Seek for RawLayerReader<R> {
     }
 }
 
-impl<R: Read + Seek> Read for RawLayerReader<R> {
+impl<R: InnerReaderTrait> Read for RawLayerReader<R> {
     /// Wrapper on inner
     fn read(&mut self, into: &mut [u8]) -> io::Result<usize> {
         self.inner.read(into)

--- a/mla/src/lib.rs
+++ b/mla/src/lib.rs
@@ -6,6 +6,7 @@ use std::io::{Read, Seek, SeekFrom, Write};
 extern crate bitflags;
 use bincode::Options;
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
+use layers::traits::InnerReaderTrait;
 use serde::{Deserialize, Serialize};
 
 pub mod layers;
@@ -847,7 +848,7 @@ pub struct FileInfo {
     eof_offset: u64,
 }
 
-pub struct ArchiveReader<'a, R: 'a + Read + Seek> {
+pub struct ArchiveReader<'a, R: 'a + InnerReaderTrait> {
     /// MLA Archive format Reader
 
     /// User's reading configuration
@@ -858,7 +859,7 @@ pub struct ArchiveReader<'a, R: 'a + Read + Seek> {
     metadata: Option<ArchiveFooter>,
 }
 
-impl<'b, R: 'b + Read + Seek> ArchiveReader<'b, R> {
+impl<'b, R: 'b + InnerReaderTrait> ArchiveReader<'b, R> {
     pub fn from_config(mut src: R, mut config: ArchiveReaderConfig) -> Result<Self, Error> {
         // Make sure we read the archive header from the start
         src.rewind()?;
@@ -2187,5 +2188,6 @@ pub(crate) mod tests {
         static_assertions::assert_cfg!(feature = "send");
         static_assertions::assert_impl_all!(File: Send);
         static_assertions::assert_impl_all!(ArchiveWriter<File>: Send);
+        static_assertions::assert_impl_all!(ArchiveReader<File>: Send);
     }
 }

--- a/mlar/src/main.rs
+++ b/mlar/src/main.rs
@@ -12,7 +12,7 @@ use mla::helpers::linear_extract;
 use mla::layers::compress::CompressionLayerReader;
 use mla::layers::encrypt::EncryptionLayerReader;
 use mla::layers::raw::RawLayerReader;
-use mla::layers::traits::LayerReader;
+use mla::layers::traits::{InnerReaderTrait, LayerReader};
 use mla::{
     ArchiveFailSafeReader, ArchiveFile, ArchiveFooter, ArchiveHeader, ArchiveReader, ArchiveWriter,
     Layers,
@@ -921,7 +921,7 @@ impl ArchiveInfoReader {
         mut config: ArchiveReaderConfig,
     ) -> Result<Self, MlarError>
     where
-        R: 'a + Read + Seek,
+        R: 'a + InnerReaderTrait,
     {
         // Make sure we read the archive header from the start
         src.rewind()?;


### PR DESCRIPTION
Mimic the behavior of the `ArchiveWriter` for `ArchiveReader` when the "send" feature is enabled.

As a result, when the feature "send" is enabled, `ArchiveReader` is now `Send`