### PR TITLE
Initial Python binding support

### DIFF
--- a/.github/workflows/py-bindings.yml
+++ b/.github/workflows/py-bindings.yml
@@ -42,7 +42,7 @@ jobs:
         shell: bash
         run: |
           set -e
-          pip install mla --find-links dist --force-reinstall
+          pip install mla-archive --find-links dist --force-reinstall
           pip install pytest
           cd bindings/python && pytest
 
@@ -72,7 +72,7 @@ jobs:
         shell: bash
         run: |
           set -e
-          pip install mla --find-links dist --force-reinstall
+          pip install mla-archive --find-links dist --force-reinstall
           pip install pytest
           cd bindings/python && pytest
 
@@ -102,7 +102,7 @@ jobs:
         shell: bash
         run: |
           set -e
-          pip install mla --find-links dist --force-reinstall
+          pip install mla-archive --find-links dist --force-reinstall
           pip install pytest
           cd bindings/python && pytest
 

--- a/.github/workflows/py-bindings.yml
+++ b/.github/workflows/py-bindings.yml
@@ -1,0 +1,108 @@
+# This file is based on the output of:
+#
+#    maturin generate-ci github --pytest -m bindings/python/Cargo.toml
+#
+# Using maturin v1.4.0
+name: Py-bindings
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+permissions:
+  contents: read
+
+jobs:
+  linux:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        target: [x86_64, x86, aarch64, armv7, s390x, ppc64le]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - name: Build wheels
+        uses: PyO3/maturin-action@v1
+        with:
+          target: ${{ matrix.target }}
+          args: --release --out dist --find-interpreter --manifest-path bindings/python/Cargo.toml
+          sccache: 'true'
+          manylinux: auto
+      - name: Upload wheels
+        uses: actions/upload-artifact@v3
+        with:
+          name: wheels
+          path: dist
+      - name: pytest
+        if: ${{ startsWith(matrix.target, 'x86_64') }}
+        shell: bash
+        run: |
+          set -e
+          pip install mla --find-links dist --force-reinstall
+          pip install pytest
+          cd bindings/python && pytest
+
+  windows:
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        target: [x64, x86]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+          architecture: ${{ matrix.target }}
+      - name: Build wheels
+        uses: PyO3/maturin-action@v1
+        with:
+          target: ${{ matrix.target }}
+          args: --release --out dist --find-interpreter --manifest-path bindings/python/Cargo.toml
+          sccache: 'true'
+      - name: Upload wheels
+        uses: actions/upload-artifact@v3
+        with:
+          name: wheels
+          path: dist
+      - name: pytest
+        shell: bash
+        run: |
+          set -e
+          pip install mla --find-links dist --force-reinstall
+          pip install pytest
+          cd bindings/python && pytest
+
+  macos:
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        target: [x86_64, aarch64]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - name: Build wheels
+        uses: PyO3/maturin-action@v1
+        with:
+          target: ${{ matrix.target }}
+          args: --release --out dist --find-interpreter --manifest-path bindings/python/Cargo.toml
+          sccache: 'true'
+      - name: Upload wheels
+        uses: actions/upload-artifact@v3
+        with:
+          name: wheels
+          path: dist
+      - name: pytest
+        if: ${{ !startsWith(matrix.target, 'aarch64') }}
+        shell: bash
+        run: |
+          set -e
+          pip install mla --find-links dist --force-reinstall
+          pip install pytest
+          cd bindings/python && pytest
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,6 @@ members = [
     "mlar",
     "mla-fuzz-afl",
     "bindings/C",
-    "bindings/python",
 ]
 
 [profile.release]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "mlar",
     "mla-fuzz-afl",
     "bindings/C",
+    "bindings/python",
 ]
 
 [profile.release]

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "pymla"
+version = "0.1.0"
+edition = "2021"
+authors = ["Camille Mougey <camille.mougey@ssi.gouv.fr>"]
+license = "LGPL-3.0-only"
+description = "Multi Layer Archive - A pure rust encrypted and compressed archive file format"
+homepage = "https://github.com/ANSSI-FR/MLA"
+repository = "https://github.com/ANSSI-FR/MLA"
+readme = "../../README.md"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[lib]
+name = "pymla"
+crate-type = ["cdylib"]
+
+[dependencies]
+pyo3 = "0.19.0"
+mla = { version = "1", features = ["send"], path = "../../mla"}

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -17,3 +17,5 @@ crate-type = ["cdylib"]
 [dependencies]
 pyo3 = "0.19.0"
 mla = { version = "1", features = ["send"], path = "../../mla"}
+x25519-dalek = "2"
+curve25519-parser = { path = "../../curve25519-parser", version = "0.4" }

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -9,13 +9,17 @@ homepage = "https://github.com/ANSSI-FR/MLA"
 repository = "https://github.com/ANSSI-FR/MLA"
 readme = "../../README.md"
 
+# Avoid cargo feature unification, which might broke other build in the workspace
+[workspace]
+members = ["."]
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [lib]
 name = "pymla"
 crate-type = ["cdylib"]
 
 [dependencies]
-pyo3 = "0.19.0"
+pyo3 = "0"
 mla = { version = "1", features = ["send"], path = "../../mla"}
 x25519-dalek = "2"
 curve25519-parser = { path = "../../curve25519-parser", version = "0.4" }

--- a/bindings/python/LICENSE.md
+++ b/bindings/python/LICENSE.md
@@ -1,0 +1,165 @@
+                   GNU LESSER GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+
+  This version of the GNU Lesser General Public License incorporates
+the terms and conditions of version 3 of the GNU General Public
+License, supplemented by the additional permissions listed below.
+
+  0. Additional Definitions.
+
+  As used herein, "this License" refers to version 3 of the GNU Lesser
+General Public License, and the "GNU GPL" refers to version 3 of the GNU
+General Public License.
+
+  "The Library" refers to a covered work governed by this License,
+other than an Application or a Combined Work as defined below.
+
+  An "Application" is any work that makes use of an interface provided
+by the Library, but which is not otherwise based on the Library.
+Defining a subclass of a class defined by the Library is deemed a mode
+of using an interface provided by the Library.
+
+  A "Combined Work" is a work produced by combining or linking an
+Application with the Library.  The particular version of the Library
+with which the Combined Work was made is also called the "Linked
+Version".
+
+  The "Minimal Corresponding Source" for a Combined Work means the
+Corresponding Source for the Combined Work, excluding any source code
+for portions of the Combined Work that, considered in isolation, are
+based on the Application, and not on the Linked Version.
+
+  The "Corresponding Application Code" for a Combined Work means the
+object code and/or source code for the Application, including any data
+and utility programs needed for reproducing the Combined Work from the
+Application, but excluding the System Libraries of the Combined Work.
+
+  1. Exception to Section 3 of the GNU GPL.
+
+  You may convey a covered work under sections 3 and 4 of this License
+without being bound by section 3 of the GNU GPL.
+
+  2. Conveying Modified Versions.
+
+  If you modify a copy of the Library, and, in your modifications, a
+facility refers to a function or data to be supplied by an Application
+that uses the facility (other than as an argument passed when the
+facility is invoked), then you may convey a copy of the modified
+version:
+
+   a) under this License, provided that you make a good faith effort to
+   ensure that, in the event an Application does not supply the
+   function or data, the facility still operates, and performs
+   whatever part of its purpose remains meaningful, or
+
+   b) under the GNU GPL, with none of the additional permissions of
+   this License applicable to that copy.
+
+  3. Object Code Incorporating Material from Library Header Files.
+
+  The object code form of an Application may incorporate material from
+a header file that is part of the Library.  You may convey such object
+code under terms of your choice, provided that, if the incorporated
+material is not limited to numerical parameters, data structure
+layouts and accessors, or small macros, inline functions and templates
+(ten or fewer lines in length), you do both of the following:
+
+   a) Give prominent notice with each copy of the object code that the
+   Library is used in it and that the Library and its use are
+   covered by this License.
+
+   b) Accompany the object code with a copy of the GNU GPL and this license
+   document.
+
+  4. Combined Works.
+
+  You may convey a Combined Work under terms of your choice that,
+taken together, effectively do not restrict modification of the
+portions of the Library contained in the Combined Work and reverse
+engineering for debugging such modifications, if you also do each of
+the following:
+
+   a) Give prominent notice with each copy of the Combined Work that
+   the Library is used in it and that the Library and its use are
+   covered by this License.
+
+   b) Accompany the Combined Work with a copy of the GNU GPL and this license
+   document.
+
+   c) For a Combined Work that displays copyright notices during
+   execution, include the copyright notice for the Library among
+   these notices, as well as a reference directing the user to the
+   copies of the GNU GPL and this license document.
+
+   d) Do one of the following:
+
+       0) Convey the Minimal Corresponding Source under the terms of this
+       License, and the Corresponding Application Code in a form
+       suitable for, and under terms that permit, the user to
+       recombine or relink the Application with a modified version of
+       the Linked Version to produce a modified Combined Work, in the
+       manner specified by section 6 of the GNU GPL for conveying
+       Corresponding Source.
+
+       1) Use a suitable shared library mechanism for linking with the
+       Library.  A suitable mechanism is one that (a) uses at run time
+       a copy of the Library already present on the user's computer
+       system, and (b) will operate properly with a modified version
+       of the Library that is interface-compatible with the Linked
+       Version.
+
+   e) Provide Installation Information, but only if you would otherwise
+   be required to provide such information under section 6 of the
+   GNU GPL, and only to the extent that such information is
+   necessary to install and execute a modified version of the
+   Combined Work produced by recombining or relinking the
+   Application with a modified version of the Linked Version. (If
+   you use option 4d0, the Installation Information must accompany
+   the Minimal Corresponding Source and Corresponding Application
+   Code. If you use option 4d1, you must provide the Installation
+   Information in the manner specified by section 6 of the GNU GPL
+   for conveying Corresponding Source.)
+
+  5. Combined Libraries.
+
+  You may place library facilities that are a work based on the
+Library side by side in a single library together with other library
+facilities that are not Applications and are not covered by this
+License, and convey such a combined library under terms of your
+choice, if you do both of the following:
+
+   a) Accompany the combined library with a copy of the same work based
+   on the Library, uncombined with any other library facilities,
+   conveyed under the terms of this License.
+
+   b) Give prominent notice with the combined library that part of it
+   is a work based on the Library, and explaining where to find the
+   accompanying uncombined form of the same work.
+
+  6. Revised Versions of the GNU Lesser General Public License.
+
+  The Free Software Foundation may publish revised and/or new versions
+of the GNU Lesser General Public License from time to time. Such new
+versions will be similar in spirit to the present version, but may
+differ in detail to address new problems or concerns.
+
+  Each version is given a distinguishing version number. If the
+Library as you received it specifies that a certain numbered version
+of the GNU Lesser General Public License "or any later version"
+applies to it, you have the option of following the terms and
+conditions either of that published version or of any later version
+published by the Free Software Foundation. If the Library as you
+received it does not specify a version number of the GNU Lesser
+General Public License, you may choose any version of the GNU Lesser
+General Public License ever published by the Free Software Foundation.
+
+  If the Library as you received it specifies that a proxy can decide
+whether future versions of the GNU Lesser General Public License shall
+apply, that proxy's public statement of acceptance of any version is
+permanent authorization for you to choose that version for the
+Library.

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -1,0 +1,24 @@
+[build-system]
+requires = ["maturin>=1.4,<2.0"]
+build-backend = "maturin"
+
+[project]
+name = "mla"
+description = "Bindings for MLA Archive manipulation"
+requires-python = ">=3.8"
+keywords = ["archive", "mla"]
+license = {file = "../../LICENSE.md"}
+classifiers = [
+    "Programming Language :: Rust",
+    "Programming Language :: Python :: Implementation :: CPython",
+    "Programming Language :: Python :: Implementation :: PyPy",
+]
+dynamic = ["version"]
+
+[project.urls]
+documentation = "https://github.com/ANSSI-FR/MLA"
+repository = "https://github.com/ANSSI-FR/MLA"
+
+[tool.maturin]
+features = ["pyo3/extension-module"]
+module-name = "mla"

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -3,11 +3,14 @@ requires = ["maturin>=1.4,<2.0"]
 build-backend = "maturin"
 
 [project]
-name = "mla"
+name = "mla-archive"
 description = "Bindings for MLA Archive manipulation"
+authors = [
+    { name="Mougey Camille", email="camille.mougey@ssi.gouv.fr" },
+]
 requires-python = ">=3.8"
 keywords = ["archive", "mla"]
-license = {file = "../../LICENSE.md"}
+license = {file = "LICENSE.md"}
 classifiers = [
     "Programming Language :: Rust",
     "Programming Language :: Python :: Implementation :: CPython",

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -308,7 +308,7 @@ impl WriterConfig {
             Some(layers_enabled) => Layers::from_bits(layers_enabled).ok_or(
                 mla::errors::Error::BadAPIArgument(format!("Unknown layers")),
             )?,
-            None => Layers::EMPTY,
+            None => Layers::DEFAULT,
         };
 
         // Check compression level is correct using a fake object

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -1,0 +1,598 @@
+use std::{borrow::Cow, collections::HashMap, io::Read};
+
+use mla::{
+    config::{ArchiveReaderConfig, ArchiveWriterConfig},
+    ArchiveReader, ArchiveWriter, Layers,
+};
+use pyo3::{
+    create_exception,
+    exceptions::{PyKeyError, PyRuntimeError},
+    prelude::*,
+};
+
+// -------- Error handling --------
+
+/// Wrapper over MLA custom error, due to the "orphan rule"
+/// - WrappedMLA: MLA specifics errors
+/// - WrappedPy: Python related errors
+#[derive(Debug)]
+enum WrappedError {
+    WrappedMLA(mla::errors::Error),
+    WrappedPy(PyErr),
+}
+
+// Add a dedicated MLA Exception (mla.MLAError) and associated sub-Exception
+// IOError and AssertionError are not mapped, as they already map to Python Exception
+create_exception!(mla, MLAError, pyo3::exceptions::PyException);
+create_exception!(mla, WrongMagic, MLAError, "Wrong magic, must be \"MLA\"");
+create_exception!(
+    mla,
+    UnsupportedVersion,
+    MLAError,
+    "Unsupported version, must be 1"
+);
+create_exception!(
+    mla,
+    InvalidECCKeyFormat,
+    MLAError,
+    "Supplied ECC key is not in the expected format"
+);
+create_exception!(mla, WrongBlockSubFileType, MLAError, "Wrong BlockSubFile magic has been encountered. Is the deserializion tarting at the beginning of a block?");
+create_exception!(
+    mla,
+    UTF8ConversionError,
+    MLAError,
+    "An error has occurred while converting into UTF8. This error could"
+);
+create_exception!(
+    mla,
+    FilenameTooLong,
+    MLAError,
+    "Filenames have a limited size `FILENAME_MAX_SIZE`"
+);
+create_exception!(
+    mla,
+    WrongArchiveWriterState,
+    MLAError,
+    "The writer state is not in the expected state for the current operation"
+);
+create_exception!(
+    mla,
+    WrongReaderState,
+    MLAError,
+    "The reader state is not in the expected state for the current operation"
+);
+create_exception!(
+    mla,
+    WrongWriterState,
+    MLAError,
+    "The writer state is not in the expected state for the current operation"
+);
+create_exception!(
+    mla,
+    RandError,
+    MLAError,
+    "Error with the inner random generator"
+);
+create_exception!(
+    mla,
+    PrivateKeyNeeded,
+    MLAError,
+    "A Private Key is required to decrypt the encrypted cipher key"
+);
+create_exception!(
+    mla,
+    DeserializationError,
+    MLAError,
+    "Deserialization error. May happens when starting from a wrong offset / version mismatch"
+);
+create_exception!(
+    mla,
+    SerializationError,
+    MLAError,
+    "Serialization error. May happens on I/O errors"
+);
+create_exception!(mla, MissingMetadata, MLAError, "Missing metadata (usually means the footer has not been correctly read, a repair might be needed)");
+create_exception!(
+    mla,
+    BadAPIArgument,
+    MLAError,
+    "Error returned on API call with incorrect argument"
+);
+create_exception!(
+    mla,
+    EndOfStream,
+    MLAError,
+    "End of stream reached, no more data should be expected"
+);
+create_exception!(
+    mla,
+    ConfigError,
+    MLAError,
+    "An error happens in the configuration"
+);
+create_exception!(mla, DuplicateFilename, MLAError, "Filename already used");
+create_exception!(
+    mla,
+    AuthenticatedDecryptionWrongTag,
+    MLAError,
+    "Wrong tag while decrypting authenticated data"
+);
+create_exception!(
+    mla,
+    HKDFInvalidKeyLength,
+    MLAError,
+    "Unable to expand while using the HKDF"
+);
+
+// Convert potentials errors to the wrapped type
+
+impl From<mla::errors::Error> for WrappedError {
+    fn from(err: mla::errors::Error) -> Self {
+        WrappedError::WrappedMLA(err)
+    }
+}
+
+impl From<mla::errors::ConfigError> for WrappedError {
+    fn from(err: mla::errors::ConfigError) -> Self {
+        WrappedError::WrappedMLA(mla::errors::Error::ConfigError(err))
+    }
+}
+
+impl From<std::io::Error> for WrappedError {
+    fn from(err: std::io::Error) -> Self {
+        WrappedError::WrappedPy(err.into())
+    }
+}
+
+/// Convert back the wrapped type to Python errors
+impl From<WrappedError> for PyErr {
+    fn from(err: WrappedError) -> PyErr {
+        match err {
+            WrappedError::WrappedMLA(inner_err) => {
+                match inner_err {
+                    mla::errors::Error::IOError(err) => PyErr::new::<pyo3::exceptions::PyIOError, _>(err),
+                    mla::errors::Error::AssertionError(msg) => PyErr::new::<pyo3::exceptions::PyAssertionError, _>(msg),
+                    mla::errors::Error::WrongMagic => PyErr::new::<WrongMagic, _>("Wrong magic, must be \"MLA\""),
+                    mla::errors::Error::UnsupportedVersion => PyErr::new::<UnsupportedVersion, _>("Unsupported version, must be 1"),
+                    mla::errors::Error::InvalidECCKeyFormat => PyErr::new::<InvalidECCKeyFormat, _>("Supplied ECC key is not in the expected format"),
+                    mla::errors::Error::WrongBlockSubFileType => PyErr::new::<WrongBlockSubFileType, _>("Wrong BlockSubFile magic has been encountered. Is the deserializion tarting at the beginning of a block?"),
+                    mla::errors::Error::UTF8ConversionError(err) => PyErr::new::<UTF8ConversionError, _>(err),
+                    mla::errors::Error::FilenameTooLong => PyErr::new::<FilenameTooLong, _>("Filenames have a limited size `FILENAME_MAX_SIZE`"),
+                    mla::errors::Error::WrongArchiveWriterState { current_state, expected_state } => PyErr::new::<WrongArchiveWriterState, _>(format!("The writer state is not in the expected state for the current operation. Current state: {:?}, expected state: {:?}", current_state, expected_state)),
+                    mla::errors::Error::WrongReaderState(msg) => PyErr::new::<WrongReaderState, _>(msg),
+                    mla::errors::Error::WrongWriterState(msg) => PyErr::new::<WrongWriterState, _>(msg),
+                    mla::errors::Error::RandError(err) => PyErr::new::<RandError, _>(format!("{:}", err)),
+                    mla::errors::Error::PrivateKeyNeeded => PyErr::new::<PrivateKeyNeeded, _>("A Private Key is required to decrypt the encrypted cipher key"),
+                    mla::errors::Error::DeserializationError => PyErr::new::<DeserializationError, _>("Deserialization error. May happens when starting from a wrong offset / version mismatch"),
+                    mla::errors::Error::SerializationError => PyErr::new::<SerializationError, _>("Serialization error. May happens on I/O errors"),
+                    mla::errors::Error::MissingMetadata => PyErr::new::<MissingMetadata, _>("Missing metadata (usually means the footer has not been correctly read, a repair might be needed)"),
+                    mla::errors::Error::BadAPIArgument(msg) => PyErr::new::<BadAPIArgument, _>(msg),
+                    mla::errors::Error::EndOfStream => PyErr::new::<EndOfStream, _>("End of stream reached, no more data should be expected"),
+                    mla::errors::Error::ConfigError(err) => PyErr::new::<ConfigError, _>(format!("{:}", err)),
+                    mla::errors::Error::DuplicateFilename => PyErr::new::<DuplicateFilename, _>("Filename already used"),
+                    mla::errors::Error::AuthenticatedDecryptionWrongTag => PyErr::new::<AuthenticatedDecryptionWrongTag, _>("Wrong tag while decrypting authenticated data"),
+                    mla::errors::Error::HKDFInvalidKeyLength => PyErr::new::<HKDFInvalidKeyLength, _>("Unable to expand while using the HKDF"),
+                }
+            },
+            WrappedError::WrappedPy(inner_err) => inner_err
+        }
+    }
+}
+
+// -------- mla.FileMetadata --------
+
+#[pyclass]
+struct FileMetadata {
+    size: Option<u64>,
+    hash: Option<[u8; 32]>,
+}
+
+#[pymethods]
+impl FileMetadata {
+    #[getter]
+    fn size(&self) -> Option<u64> {
+        self.size
+    }
+
+    #[getter]
+    fn hash(&self) -> Option<Cow<[u8]>> {
+        match self.hash {
+            Some(ref hash) => Some(Cow::Borrowed(hash)),
+            None => None,
+        }
+    }
+
+    fn __repr__(&self) -> String {
+        format!("<FileMetadata size={:?} hash={:?}>", self.size, self.hash)
+    }
+}
+
+// -------- mla.ConfigWriter --------
+
+// from mla::layers::DEFAULT_COMPRESSION_LEVEL
+const DEFAULT_COMPRESSION_LEVEL: u32 = 5;
+
+#[pyclass]
+struct WriterConfig {
+    inner: ArchiveWriterConfig,
+}
+
+#[pymethods]
+impl WriterConfig {
+    #[new]
+    #[pyo3(signature = (layers=None, compression_level=DEFAULT_COMPRESSION_LEVEL))]
+    fn new(layers: Option<u8>, compression_level: u32) -> Result<Self, WrappedError> {
+        let mut output = WriterConfig {
+            inner: ArchiveWriterConfig::new(),
+        };
+        if let Some(layers_enabled) = layers {
+            output
+                .inner
+                .set_layers(Layers::from_bits(layers_enabled).ok_or(
+                    mla::errors::Error::BadAPIArgument(format!("Unknown layers")),
+                )?);
+        }
+        output.inner.with_compression_level(compression_level)?;
+
+        Ok(output)
+    }
+
+    #[getter]
+    fn layers(&self) -> Result<u8, WrappedError> {
+        Ok(self.inner.to_persistent()?.layers_enabled.bits())
+    }
+
+    /// Enable a layer
+    fn enable_layer(mut slf: PyRefMut<Self>, layer: u8) -> Result<PyRefMut<Self>, WrappedError> {
+        slf.inner.enable_layer(
+            Layers::from_bits(layer)
+                .ok_or(mla::errors::Error::BadAPIArgument(format!("Unknown layer")))?,
+        );
+        Ok(slf)
+    }
+
+    /// Disable a layer
+    fn disable_layer(mut slf: PyRefMut<Self>, layer: u8) -> Result<PyRefMut<Self>, WrappedError> {
+        slf.inner.disable_layer(
+            Layers::from_bits(layer)
+                .ok_or(mla::errors::Error::BadAPIArgument(format!("Unknown layer")))?,
+        );
+        Ok(slf)
+    }
+
+    /// Set several layers at once
+    fn set_layers(mut slf: PyRefMut<Self>, layers: u8) -> Result<PyRefMut<Self>, WrappedError> {
+        slf.inner.set_layers(Layers::from_bits(layers).ok_or(
+            mla::errors::Error::BadAPIArgument(format!("Unknown layers")),
+        )?);
+        Ok(slf)
+    }
+
+    /// Set the compression level
+    /// compression level (0-11); bigger values cause denser, but slower compression
+    fn with_compression_level(
+        mut slf: PyRefMut<Self>,
+        compression_level: u32,
+    ) -> Result<PyRefMut<Self>, WrappedError> {
+        slf.inner.with_compression_level(compression_level)?;
+        Ok(slf)
+    }
+}
+
+// -------- mla.MLAFile --------
+
+/// `ArchiveWriter` is a generic type. To avoid generating several Python implementation
+/// (see https://pyo3.rs/v0.20.2/class.html#no-generic-parameters), this enum explicitely
+/// instanciate `ArchiveWriter` for common & expected types
+///
+/// Additionnaly, as the GC in Python might drop objects at any time, we need to use
+/// `'static` lifetime for the writer. This should not be a problem as the writer is not
+/// supposed to be used after the drop of the parent object
+/// (see https://pyo3.rs/v0.20.2/class.html#no-lifetime-parameters)
+enum ExplicitWriters {
+    FileWriter(ArchiveWriter<'static, std::fs::File>),
+}
+
+/// Wrap calls to the inner type
+impl ExplicitWriters {
+    fn finalize(&mut self) -> Result<(), mla::errors::Error> {
+        match self {
+            ExplicitWriters::FileWriter(writer) => {
+                writer.finalize()?;
+                Ok(())
+            }
+        }
+    }
+}
+
+/// See `ExplicitWriters` for details
+enum ExplicitReaders {
+    FileReader(ArchiveReader<'static, std::fs::File>),
+}
+
+/// Wrap calls to the inner type
+impl ExplicitReaders {
+    fn list_files(&self) -> Result<impl Iterator<Item = &String>, mla::errors::Error> {
+        match self {
+            ExplicitReaders::FileReader(reader) => reader.list_files(),
+        }
+    }
+}
+
+/// Opening Mode for a MLAFile
+enum OpeningModeInner {
+    Read(ExplicitReaders),
+    Write(ExplicitWriters),
+}
+
+#[pyclass]
+pub struct MLAFile {
+    /// Wrapping over the rust object, depending on the opening mode
+    inner: OpeningModeInner,
+    /// Path of the file, used for messages
+    path: String,
+}
+
+/// Used to check whether the opening mode is the expected one, and unwrap it
+/// return a BadAPI argument error if not
+/// ```text
+/// let inner = check_mode!(self, Read);
+/// ```
+macro_rules! check_mode {
+    ( $self:expr, $x:ident ) => {{
+        match &$self.inner {
+            OpeningModeInner::$x(inner) => inner,
+            _ => {
+                return Err(mla::errors::Error::BadAPIArgument(format!(
+                    "This API is only callable in {:} mode",
+                    stringify!($x)
+                ))
+                .into())
+            }
+        }
+    }};
+    ( mut $self:expr, $x:ident ) => {{
+        match &mut $self.inner {
+            OpeningModeInner::$x(inner) => inner,
+            _ => {
+                return Err(mla::errors::Error::BadAPIArgument(format!(
+                    "This API is only callable in {:} mode",
+                    stringify!($x)
+                ))
+                .into())
+            }
+        }
+    }};
+}
+
+#[pymethods]
+impl MLAFile {
+    #[new]
+    #[pyo3(signature = (path, mode="r"))]
+    fn new(path: &str, mode: &str) -> Result<Self, WrappedError> {
+        match mode {
+            "r" => {
+                let config = ArchiveReaderConfig::new();
+                let input_file = std::fs::File::open(path)?;
+                let arch_reader = ArchiveReader::from_config(input_file, config)?;
+                Ok(MLAFile {
+                    inner: OpeningModeInner::Read(ExplicitReaders::FileReader(arch_reader)),
+                    path: path.to_string(),
+                })
+            }
+            "w" => {
+                let mut config = ArchiveWriterConfig::new();
+                config.enable_layer(Layers::COMPRESS);
+                let output_file = std::fs::File::create(path)?;
+                let arch_writer = ArchiveWriter::from_config(output_file, config)?;
+                Ok(MLAFile {
+                    inner: OpeningModeInner::Write(ExplicitWriters::FileWriter(arch_writer)),
+                    path: path.to_string(),
+                })
+            }
+            _ => Err(mla::errors::Error::BadAPIArgument(format!(
+                "Unknown mode {}, use 'r' or 'w'",
+                mode
+            ))
+            .into()),
+        }
+    }
+
+    fn __repr__(&self) -> String {
+        format!(
+            "<MLAFile path='{:}' mode='{:}'>",
+            self.path,
+            match self.inner {
+                OpeningModeInner::Read(_) => "r",
+                OpeningModeInner::Write(_) => "w",
+            }
+        )
+    }
+
+    /// Return the list of files in the archive
+    fn keys(&self) -> Result<Vec<String>, WrappedError> {
+        let inner = check_mode!(self, Read);
+        Ok(inner.list_files()?.map(|x| x.to_string()).collect())
+    }
+
+    /// Return the size of a file in the archive
+    #[pyo3(signature = (include_size=false, include_hash=false))]
+    fn list_files(
+        &mut self,
+        include_size: bool,
+        include_hash: bool,
+    ) -> Result<HashMap<String, FileMetadata>, WrappedError> {
+        let inner = check_mode!(mut self, Read);
+
+        let mut output = HashMap::new();
+        let iter: Vec<String> = inner.list_files()?.cloned().collect();
+        for fname in iter {
+            let mut metadata = FileMetadata {
+                size: None,
+                hash: None,
+            };
+            match inner {
+                ExplicitReaders::FileReader(mla) => {
+                    if include_size {
+                        metadata.size = Some(
+                            mla.get_file(fname.clone())?
+                                .ok_or(WrappedError::WrappedPy(PyRuntimeError::new_err(format!(
+                                    "File {} not found",
+                                    fname
+                                ))))?
+                                .size,
+                        );
+                    }
+                    if include_hash {
+                        metadata.hash =
+                            Some(mla.get_hash(&fname)?.ok_or(WrappedError::WrappedPy(
+                                PyRuntimeError::new_err(format!("File {} not found", fname)),
+                            ))?);
+                    }
+                }
+            }
+            output.insert(fname.to_string(), metadata);
+        }
+        Ok(output)
+    }
+
+    /// Return whether the file is in the archive
+    fn __contains__(&self, key: &str) -> Result<bool, WrappedError> {
+        let inner = check_mode!(self, Read);
+        Ok(inner.list_files()?.any(|x| x == key))
+    }
+
+    /// Return the content of a file as bytes
+    fn __getitem__(&mut self, key: &str) -> Result<Cow<[u8]>, WrappedError> {
+        let inner = check_mode!(mut self, Read);
+        match inner {
+            ExplicitReaders::FileReader(reader) => {
+                let mut buf = Vec::new();
+                let file = reader.get_file(key.to_string())?;
+                if let Some(mut archive_file) = file {
+                    archive_file.data.read_to_end(&mut buf)?;
+                    Ok(Cow::Owned(buf))
+                } else {
+                    Err(WrappedError::WrappedPy(PyKeyError::new_err(format!(
+                        "File {} not found",
+                        key
+                    )))
+                    .into())
+                }
+            }
+        }
+    }
+
+    /// Add a file to the archive
+    fn __setitem__(&mut self, key: &str, value: &[u8]) -> Result<(), WrappedError> {
+        let writer = check_mode!(mut self, Write);
+        match writer {
+            ExplicitWriters::FileWriter(writer) => {
+                let mut reader = std::io::Cursor::new(value);
+                writer.add_file(key, value.len() as u64, &mut reader)?;
+                Ok(())
+            }
+        }
+    }
+
+    /// Return the number of file in the archive
+    fn __len__(&self) -> Result<usize, WrappedError> {
+        let inner = check_mode!(self, Read);
+        Ok(inner.list_files()?.count())
+    }
+
+    /// Finalize the archive creation. This API *must* be called or essential records will no be written
+    /// An archive can only be finalized once
+    fn finalize(&mut self) -> Result<(), WrappedError> {
+        let inner = check_mode!(mut self, Write);
+        Ok(inner.finalize()?)
+    }
+
+    // Context management protocol (PEP 0343)
+    // https://docs.python.org/3/reference/datamodel.html#context-managers
+    fn __enter__(slf: PyRef<Self>) -> PyRef<Self> {
+        slf
+    }
+
+    fn __exit__(
+        &mut self,
+        exc_type: Option<&PyAny>,
+        _exc_value: Option<&PyAny>,
+        _traceback: Option<&PyAny>,
+    ) -> Result<bool, WrappedError> {
+        if exc_type.is_some() {
+            // An exception occured, let it be raised again
+            return Ok(false);
+        }
+
+        match self.inner {
+            OpeningModeInner::Read(_) => {
+                // Nothing to do, dropping this object should close the inner stream
+            }
+            OpeningModeInner::Write(ref mut writer) => {
+                // Finalize. If an exception occured, raise it
+                writer.finalize()?;
+            }
+        }
+        Ok(false)
+    }
+}
+
+// -------- Python module instanciation --------
+
+/// Instanciate the Python module
+#[pymodule]
+#[pyo3(name = "mla")]
+fn pymla(py: Python, m: &PyModule) -> PyResult<()> {
+    // Classes
+    m.add_class::<MLAFile>()?;
+    m.add_class::<FileMetadata>()?;
+    m.add_class::<WriterConfig>()?;
+
+    // Exceptions
+    m.add("MLAError", py.get_type::<MLAError>())?;
+    m.add("WrongMagic", py.get_type::<WrongMagic>())?;
+    m.add("UnsupportedVersion", py.get_type::<UnsupportedVersion>())?;
+    m.add("InvalidECCKeyFormat", py.get_type::<InvalidECCKeyFormat>())?;
+    m.add(
+        "WrongBlockSubFileType",
+        py.get_type::<WrongBlockSubFileType>(),
+    )?;
+    m.add("UTF8ConversionError", py.get_type::<UTF8ConversionError>())?;
+    m.add("FilenameTooLong", py.get_type::<FilenameTooLong>())?;
+    m.add(
+        "WrongArchiveWriterState",
+        py.get_type::<WrongArchiveWriterState>(),
+    )?;
+    m.add("WrongReaderState", py.get_type::<WrongReaderState>())?;
+    m.add("WrongWriterState", py.get_type::<WrongWriterState>())?;
+    m.add("RandError", py.get_type::<RandError>())?;
+    m.add("PrivateKeyNeeded", py.get_type::<PrivateKeyNeeded>())?;
+    m.add(
+        "DeserializationError",
+        py.get_type::<DeserializationError>(),
+    )?;
+    m.add("SerializationError", py.get_type::<SerializationError>())?;
+    m.add("MissingMetadata", py.get_type::<MissingMetadata>())?;
+    m.add("BadAPIArgument", py.get_type::<BadAPIArgument>())?;
+    m.add("EndOfStream", py.get_type::<EndOfStream>())?;
+    m.add("ConfigError", py.get_type::<ConfigError>())?;
+    m.add("DuplicateFilename", py.get_type::<DuplicateFilename>())?;
+    m.add(
+        "AuthenticatedDecryptionWrongTag",
+        py.get_type::<AuthenticatedDecryptionWrongTag>(),
+    )?;
+    m.add(
+        "HKDFInvalidKeyLength",
+        py.get_type::<HKDFInvalidKeyLength>(),
+    )?;
+
+    // Add constants
+    m.add("LAYER_COMPRESS", Layers::COMPRESS.bits())?;
+    m.add("LAYER_ENCRYPT", Layers::ENCRYPT.bits())?;
+    m.add("LAYER_DEFAULT", Layers::DEFAULT.bits())?;
+    m.add("LAYER_EMPTY", Layers::EMPTY.bits())?;
+    m.add("DEFAULT_COMPRESSION_LEVEL", DEFAULT_COMPRESSION_LEVEL)?;
+    Ok(())
+}

--- a/bindings/python/tests/test_mla.py
+++ b/bindings/python/tests/test_mla.py
@@ -322,3 +322,8 @@ def test_writer_config_public_keys():
     ))
     assert out is config
     assert len(config.public_keys.keys) == 2
+
+def test_mlafile_bad_config():
+    "Try to create a MLAFile with the wrong config parameter"
+    with pytest.raises(TypeError):
+        MLAFile(tempfile.mkstemp(suffix=".mla")[1], "w", config="NOT A CONFIG")

--- a/bindings/python/tests/test_mla.py
+++ b/bindings/python/tests/test_mla.py
@@ -1,0 +1,245 @@
+import hashlib
+import pytest
+import tempfile
+
+import mla
+from mla import MLAFile, MLAError
+
+# Test data
+FILES = {
+    "file1": b"DATA1",
+    "file2": b"DATA_2",
+}
+
+@pytest.fixture
+def basic_archive():
+    "Create a temporary archive and return its path"
+    fname = tempfile.mkstemp(suffix=".mla")[1]
+    archive = MLAFile(fname, "w")
+    for name, data in FILES.items():
+        archive[name] = data
+    archive.finalize()
+    return fname
+
+def test_layers_bitflag_export():
+    assert mla.LAYER_DEFAULT == mla.LAYER_COMPRESS | mla.LAYER_ENCRYPT
+    assert mla.LAYER_EMPTY == 0
+    assert mla.LAYER_DEFAULT != mla.LAYER_EMPTY
+
+def test_bad_mode():
+    "Ensure MLAFile with an unknown mode raise an error"
+    target_file = "/tmp/must_not_exists"
+    with pytest.raises(mla.BadAPIArgument):
+        MLAFile(target_file, "x")
+    # Ensure the file has not been created
+    with pytest.raises(FileNotFoundError):
+        open(target_file)
+
+def test_repr():
+    "Ensure the repr is correct"
+    path = tempfile.mkstemp(suffix=".mla")[1]
+    archive = MLAFile(path, "w")
+    assert repr(archive) == "<MLAFile path='%s' mode='w'>" % path
+    archive.finalize()
+
+def test_forbidden_in_write_mode():
+    "Ensure some API cannot be called in write mode"
+    archive = MLAFile(tempfile.mkstemp(suffix=".mla")[1], "w")
+
+    # .keys
+    with pytest.raises(mla.BadAPIArgument):
+        archive.keys()
+    
+    # __contains__
+    with pytest.raises(mla.BadAPIArgument):
+        "name" in archive
+    
+    # __getitem__
+    with pytest.raises(mla.BadAPIArgument):
+        archive["name"]
+    
+    # __len__
+    with pytest.raises(mla.BadAPIArgument):
+        len(archive)
+
+    # list_files
+    with pytest.raises(mla.BadAPIArgument):
+        archive.list_files()
+
+def test_forbidden_in_read_mode(basic_archive):
+    "Ensure some API cannot be called in write mode"
+    archive = MLAFile(basic_archive)
+
+    # __setitem__
+    with pytest.raises(mla.BadAPIArgument):
+        archive["file"] = b"data"
+
+    # .finalize
+    with pytest.raises(mla.BadAPIArgument):
+        archive.finalize()
+
+def test_read_api(basic_archive):
+    "Test basics read APIs"
+    archive = MLAFile(basic_archive)
+
+    # .keys
+    assert sorted(archive.keys()) == sorted(list(FILES.keys()))
+
+    # __contains__
+    assert "file1" in archive
+    assert "file3" not in archive
+
+    # __getitem__
+    assert archive["file1"] == FILES["file1"]
+    assert archive["file2"] == FILES["file2"]
+    with pytest.raises(KeyError):
+        archive["file3"]
+
+    # __len__
+    assert len(archive) == 2
+
+def test_list_files(basic_archive):
+    "Test list files possibilities"
+    archive = MLAFile(basic_archive)
+
+    # Basic
+    assert sorted(archive.list_files()) == sorted(list(FILES.keys()))
+
+    # With size
+    assert sorted([
+        (filename, info.size) for filename, info in archive.list_files(include_size=True).items()
+    ]) == sorted([
+        (filename, len(data)) for filename, data in FILES.items()
+    ])
+
+    # With hash
+    assert sorted([
+        (filename, info.hash) for filename, info in archive.list_files(include_hash=True).items()
+    ]) == sorted([
+        (filename, hashlib.sha256(data).digest()) for filename, data in FILES.items()
+    ])
+
+    # With size and hash
+    assert sorted([
+        (filename, info.size, info.hash) for filename, info in archive.list_files(include_size=True, include_hash=True).items()
+    ]) == sorted([
+        (filename, len(data), hashlib.sha256(data).digest()) for filename, data in FILES.items()
+    ])
+
+def test_write_api():
+    "Test basics write APIs"
+    path = tempfile.mkstemp(suffix=".mla")[1]
+    archive = MLAFile(path, "w")
+
+    # __setitem__
+    for name, data in FILES.items():
+        archive[name] = data
+
+    # close
+    archive.finalize()
+
+    # Check the resulting archive
+    archive = MLAFile(path)
+    assert sorted(archive.keys()) == sorted(list(FILES.keys()))
+    assert archive["file1"] == FILES["file1"]
+    assert archive["file2"] == FILES["file2"]
+
+def test_double_write():
+    "Rewriting the file must raise an MLA error"
+    archive = MLAFile(tempfile.mkstemp(suffix=".mla")[1], "w")
+    archive["file1"] = FILES["file1"]
+    
+    with pytest.raises(mla.DuplicateFilename):
+        archive["file1"] = FILES["file1"]
+
+def test_context_read(basic_archive):
+    "Test reading using a `with` statement (context management protocol)"
+    with MLAFile(basic_archive) as mla:
+        assert sorted(mla.keys()) == sorted(list(FILES.keys()))
+        for name, data in FILES.items():
+            assert mla[name] == data
+
+def test_context_write():
+    "Test writing using a `with` statement (context management protocol)"
+    path = tempfile.mkstemp(suffix=".mla")[1]
+    with MLAFile(path, "w") as mla:
+        for name, data in FILES.items():
+            mla[name] = data
+    
+    # Check the resulting file
+    with MLAFile(path) as mla:
+        assert sorted(mla.keys()) == sorted(list(FILES.keys()))
+        for name, data in FILES.items():
+            assert mla[name] == data
+
+def test_context_write_error():
+    "Raise an error during the context write __exit__"
+    with pytest.raises(mla.WrongArchiveWriterState):
+        with MLAFile(tempfile.mkstemp(suffix=".mla")[1], "w") as archive:
+            # INTENTIONNALY BUGGY
+            # .finalize will be called twice, causing an exception
+            archive.finalize()
+
+def test_context_write_error_in_with():
+    "Raise an error in the with statement, it must be re-raised"
+    CustomException = type("CustomException", (Exception,), {})
+    with pytest.raises(CustomException):
+        with MLAFile(tempfile.mkstemp(suffix=".mla")[1], "w") as mla:
+            # INTENTIONNALY BUGGY
+            raise CustomException
+
+def test_writer_config_layers():
+    "Test writer config creation for layers"
+    # Enable and disable layers
+    config = mla.WriterConfig()
+    assert config.layers == mla.LAYER_EMPTY
+
+    config = mla.WriterConfig(layers=mla.LAYER_COMPRESS)
+    assert config.layers == mla.LAYER_COMPRESS
+
+    config.enable_layer(mla.LAYER_ENCRYPT)
+    assert config.layers == mla.LAYER_COMPRESS | mla.LAYER_ENCRYPT
+
+    config.disable_layer(mla.LAYER_COMPRESS)
+    assert config.layers == mla.LAYER_ENCRYPT
+
+    config.disable_layer(mla.LAYER_ENCRYPT)
+    assert config.layers == mla.LAYER_EMPTY
+
+    # Check for error on unknown layer (0xFF)
+    with pytest.raises(mla.BadAPIArgument):
+        config.enable_layer(0xFF)
+    
+    with pytest.raises(mla.BadAPIArgument):
+        config.disable_layer(0xFF)
+    
+    with pytest.raises(mla.BadAPIArgument):
+        config.set_layers(0xFF)
+    
+    with pytest.raises(mla.BadAPIArgument):
+        config = mla.WriterConfig(layers=0xFF)
+    
+    # Chaining
+    config = mla.WriterConfig().enable_layer(
+            mla.LAYER_COMPRESS
+        ).enable_layer(
+            mla.LAYER_ENCRYPT
+        ).disable_layer(
+            mla.LAYER_COMPRESS
+        ).set_layers(
+            mla.LAYER_COMPRESS
+        )
+    assert config.layers == mla.LAYER_COMPRESS
+
+def test_writer_config_compression():
+    "Test compression API in WriterConfig creation"
+    config = mla.WriterConfig()
+    with pytest.raises(OverflowError):
+        config.with_compression_level(-1)
+    with pytest.raises(mla.ConfigError):
+        config.with_compression_level(0xFF)
+    
+    # Chaining
+    out = config.with_compression_level(mla.DEFAULT_COMPRESSION_LEVEL)
+    assert out is config
+

--- a/bindings/python/tests/test_mla.py
+++ b/bindings/python/tests/test_mla.py
@@ -369,3 +369,31 @@ def test_mlafile_bad_config():
     "Try to create a MLAFile with the wrong config parameter"
     with pytest.raises(TypeError):
         MLAFile(tempfile.mkstemp(suffix=".mla")[1], "w", config="NOT A CONFIG")
+    
+    with pytest.raises(TypeError):
+        MLAFile(tempfile.mkstemp(suffix=".mla")[1], "w", config=mla.ReaderConfig())
+    
+    with pytest.raises(TypeError):
+        MLAFile(tempfile.mkstemp(suffix=".mla")[1], "r", config=mla.WriterConfig())
+    
+
+def test_reader_config_api():
+    "Test the ReaderConfig API"
+    # Add a remove private keys
+    config = mla.ReaderConfig()
+    assert config.private_keys is None
+
+    config.set_private_keys(
+        mla.PrivateKeys(os.path.join(SAMPLE_PATH, "test_ed25519.pem"))
+    )
+    assert len(config.private_keys.keys) == 1
+
+    config = mla.ReaderConfig(private_keys=mla.PrivateKeys(os.path.join(SAMPLE_PATH, "test_ed25519.pem")))
+    assert len(config.private_keys.keys) == 1
+
+    # Chaining
+    config = mla.ReaderConfig()
+    out = config.set_private_keys(
+        mla.PrivateKeys(os.path.join(SAMPLE_PATH, "test_ed25519.pem")),
+    )
+    assert out is config

--- a/bindings/python/tests/test_mla.py
+++ b/bindings/python/tests/test_mla.py
@@ -193,7 +193,7 @@ def test_writer_config_layers():
     "Test writer config creation for layers"
     # Enable and disable layers
     config = mla.WriterConfig()
-    assert config.layers == mla.LAYER_EMPTY
+    assert config.layers == mla.LAYER_DEFAULT
 
     config = mla.WriterConfig(layers=mla.LAYER_COMPRESS)
     assert config.layers == mla.LAYER_COMPRESS

--- a/bindings/python/tests/test_mla.py
+++ b/bindings/python/tests/test_mla.py
@@ -240,6 +240,12 @@ def test_writer_config_compression():
     with pytest.raises(mla.ConfigError):
         config.with_compression_level(0xFF)
     
+    # Value
+    config.with_compression_level(mla.DEFAULT_COMPRESSION_LEVEL)
+    assert config.compression_level == mla.DEFAULT_COMPRESSION_LEVEL
+    config.with_compression_level(1)
+    assert config.compression_level == 1
+
     # Chaining
     out = config.with_compression_level(mla.DEFAULT_COMPRESSION_LEVEL)
     assert out is config
@@ -293,3 +299,26 @@ def test_public_keys():
         open(os.path.join(SAMPLE_PATH, "test_x25519_2_pub.pem"), "rb").read()
     )
     assert len(pkeys.keys) == 2
+
+def test_writer_config_public_keys():
+    "Test public keys API in WriterConfig creation"
+
+    # Test API call
+    config = mla.WriterConfig()
+    with pytest.raises(mla.InvalidECCKeyFormat):
+        config.set_public_keys(mla.PublicKeys(b"NOT A KEY"))
+    
+    # Test shortcut on object build
+    config = mla.WriterConfig(
+        public_keys=mla.PublicKeys(os.path.join(SAMPLE_PATH, "test_ed25519_pub.pem"))
+    )
+    # Test the getter
+    assert len(config.public_keys.keys) == 1
+
+    # Chaining
+    out = config.set_public_keys(mla.PublicKeys(
+        os.path.join(SAMPLE_PATH, "test_ed25519_pub.pem"),
+        open(os.path.join(SAMPLE_PATH, "test_x25519_2_pub.pem"), "rb").read()
+    ))
+    assert out is config
+    assert len(config.public_keys.keys) == 2

--- a/bindings/python/tests/test_mla.py
+++ b/bindings/python/tests/test_mla.py
@@ -300,6 +300,48 @@ def test_public_keys():
     )
     assert len(pkeys.keys) == 2
 
+def test_private_keys():
+    "Test the PrivateKeys object"
+    # Bad parsing
+    with pytest.raises(mla.InvalidECCKeyFormat):
+        mla.PrivateKeys(b"NOT A KEY")
+    
+    with pytest.raises(mla.InvalidECCKeyFormat):
+        # This is a public key, not a private one
+        mla.PrivateKeys(os.path.join(SAMPLE_PATH, "test_ed25519_pub.pem"))
+
+    with pytest.raises(FileNotFoundError):
+        mla.PrivateKeys("/tmp/does_not_exists")
+    
+    # Open a PEM key, through path
+    pkeys_pem = mla.PrivateKeys(os.path.join(SAMPLE_PATH, "test_ed25519.pem"))
+    assert len(pkeys_pem.keys) == 1
+    
+    # Open a DER key, through path
+    pkeys_der = mla.PrivateKeys(os.path.join(SAMPLE_PATH, "test_ed25519.der"))
+    assert len(pkeys_pem.keys) == 1
+
+    # Keys must be the same
+    assert pkeys_pem.keys == pkeys_der.keys
+
+    # Open a PEM key, through data
+    pkeys_pem = mla.PrivateKeys(open(os.path.join(SAMPLE_PATH, "test_ed25519.pem"), "rb").read())
+    assert len(pkeys_pem.keys) == 1
+    
+    # Open a DER key, through data
+    pkeys_pem = mla.PrivateKeys(open(os.path.join(SAMPLE_PATH, "test_ed25519.der"), "rb").read())
+    assert len(pkeys_pem.keys) == 1
+    
+    # Keys must be the same
+    assert pkeys_pem.keys == pkeys_der.keys
+
+    # Open several keys, using both path and data
+    pkeys =  mla.PrivateKeys(
+        os.path.join(SAMPLE_PATH, "test_ed25519.pem"),
+        open(os.path.join(SAMPLE_PATH, "test_x25519_2.pem"), "rb").read()
+    )
+    assert len(pkeys.keys) == 2
+
 def test_writer_config_public_keys():
     "Test public keys API in WriterConfig creation"
 

--- a/mla/src/lib.rs
+++ b/mla/src/lib.rs
@@ -478,7 +478,6 @@ impl<'a, W: InnerWriterTrait> ArchiveWriter<'a, W> {
         ArchiveHeader {
             format_version: MLA_FORMAT_VERSION,
             config: config.to_persistent()?,
-            // TODO public_key hashes for easier decryption
         }
         .dump(&mut dest)?;
 


### PR DESCRIPTION
Depends on #189 

Fix #139

Initial Python binding support, with PyO3. The build environment relies on `maturin` and the tests are made with `pytest`.
