### PR TITLE
CI: update deprecated set-output

### DIFF
--- a/.github/workflows/mla_release.yml
+++ b/.github/workflows/mla_release.yml
@@ -96,7 +96,7 @@ jobs:
         shell: bash
         run: |
           echo "using version tag ${GITHUB_REF:15}"
-          echo ::set-output name=version::"${GITHUB_REF:15}"
+          echo "version=${GITHUB_REF:15}" >> $GITHUB_OUTPUT
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Get Changelog Entry

--- a/.github/workflows/mlar_release.yml
+++ b/.github/workflows/mlar_release.yml
@@ -62,7 +62,7 @@ jobs:
         shell: bash
         run: |
           echo "using version tag ${GITHUB_REF:15}"
-          echo ::set-output name=version::"${GITHUB_REF:15}"
+          echo "version=${GITHUB_REF:15}" >> $GITHUB_OUTPUT
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Get Changelog Entry


### PR DESCRIPTION
Ref: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/