### PR TITLE
Bindings/C: fixup compilation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -107,9 +107,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions-rs/toolchain@v1
       with:
-        # Avoid a regression of Cargo, breaking at link time
-        toolchain: 1.69
-        default: true
+        toolchain: stable
         target: ${{ matrix.target }}
     - uses: microsoft/setup-msbuild@v1.0.2
     - name: Compile C/CPP bindings test program for Windows

--- a/bindings/C/Cargo.toml
+++ b/bindings/C/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mla-bindings-c"
 version = "1.0.0"
-authors = ["Matthieu Buffet <matthieu.buffet@ssi.gouv.fr>"]
+authors = ["Matthieu Buffet <matthieu.buffet@ssi.gouv.fr>","Camille Mougey <camille.mougey@ssi.gouv.fr>"]
 edition = "2018"
 
 [lib]

--- a/bindings/C/tests/windows-msvc/mla-bindings-test.vcxproj
+++ b/bindings/C/tests/windows-msvc/mla-bindings-test.vcxproj
@@ -175,7 +175,7 @@
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>DebugFull</GenerateDebugInformation>
-      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies);Ws2_32.lib;Userenv.lib;Bcrypt.lib</AdditionalDependencies>
+      <AdditionalDependencies>ntdll.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies);Ws2_32.lib;Userenv.lib;Bcrypt.lib</AdditionalDependencies>
       <AdditionalLibraryDirectories>$(SolutionDir)\..\..\..\..\target\i686-pc-windows-msvc\debug</AdditionalLibraryDirectories>
     </Link>
     <PreBuildEvent>
@@ -195,7 +195,7 @@
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>DebugFull</GenerateDebugInformation>
-      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies);Ws2_32.lib;Userenv.lib;Bcrypt.lib</AdditionalDependencies>
+      <AdditionalDependencies>ntdll.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies);Ws2_32.lib;Userenv.lib;Bcrypt.lib</AdditionalDependencies>
       <AdditionalLibraryDirectories>$(SolutionDir)\..\..\..\..\target\i686-pc-windows-msvc\debug</AdditionalLibraryDirectories>
     </Link>
     <PreBuildEvent>
@@ -219,7 +219,7 @@
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalLibraryDirectories>$(SolutionDir)\..\..\..\..\target\i686-pc-windows-msvc\release</AdditionalLibraryDirectories>
-      <AdditionalDependencies>%(AdditionalDependencies);Bcrypt.lib</AdditionalDependencies>
+      <AdditionalDependencies>%(AdditionalDependencies);Bcrypt.lib;ntdll.lib</AdditionalDependencies>
     </Link>
     <PreBuildEvent>
       <Command>if not exist "$(SolutionDir)\..\..\..\..\target\i686-pc-windows-msvc\release\mla.lib" cargo build --target=i686-pc-windows-msvc --release</Command>
@@ -242,7 +242,7 @@
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalLibraryDirectories>$(SolutionDir)\..\..\..\..\target\i686-pc-windows-msvc\release</AdditionalLibraryDirectories>
-      <AdditionalDependencies>%(AdditionalDependencies);Bcrypt.lib</AdditionalDependencies>
+      <AdditionalDependencies>%(AdditionalDependencies);Bcrypt.lib;ntdll.lib</AdditionalDependencies>
     </Link>
     <PreBuildEvent>
       <Command>if not exist "$(SolutionDir)\..\..\..\..\target\i686-pc-windows-msvc\release\mla.lib" cargo build --target=i686-pc-windows-msvc --release</Command>
@@ -261,7 +261,7 @@
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>DebugFull</GenerateDebugInformation>
-      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies);Ws2_32.lib;Userenv.lib;;Bcrypt.lib</AdditionalDependencies>
+      <AdditionalDependencies>ntdll.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies);Ws2_32.lib;Userenv.lib;;Bcrypt.lib</AdditionalDependencies>
       <AdditionalLibraryDirectories>$(SolutionDir)\..\..\..\..\target\x86_64-pc-windows-msvc\debug</AdditionalLibraryDirectories>
     </Link>
     <PreBuildEvent>
@@ -281,7 +281,7 @@
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>DebugFull</GenerateDebugInformation>
-      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies);Ws2_32.lib;Userenv.lib;Bcrypt.lib</AdditionalDependencies>
+      <AdditionalDependencies>ntdll.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies);Ws2_32.lib;Userenv.lib;Bcrypt.lib</AdditionalDependencies>
       <AdditionalLibraryDirectories>$(SolutionDir)\..\..\..\..\target\x86_64-pc-windows-msvc\debug</AdditionalLibraryDirectories>
     </Link>
     <PreBuildEvent>
@@ -305,7 +305,7 @@
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalLibraryDirectories>$(SolutionDir)\..\..\..\..\target\x86_64-pc-windows-msvc\release</AdditionalLibraryDirectories>
-      <AdditionalDependencies>%(AdditionalDependencies);Bcrypt.lib</AdditionalDependencies>
+      <AdditionalDependencies>%(AdditionalDependencies);Bcrypt.lib;ntdll.lib</AdditionalDependencies>
     </Link>
     <PreBuildEvent>
       <Command>if not exist "$(SolutionDir)\..\..\..\..\target\x86_64-pc-windows-msvc\release\mla.lib" cargo build --target=x86_64-pc-windows-msvc --release</Command>
@@ -328,7 +328,7 @@
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalLibraryDirectories>$(SolutionDir)\..\..\..\..\target\x86_64-pc-windows-msvc\release</AdditionalLibraryDirectories>
-      <AdditionalDependencies>%(AdditionalDependencies);Bcrypt.lib</AdditionalDependencies>
+      <AdditionalDependencies>%(AdditionalDependencies);Bcrypt.lib;ntdll.lib</AdditionalDependencies>
     </Link>
     <PreBuildEvent>
       <Command>if not exist "$(SolutionDir)\..\..\..\..\target\x86_64-pc-windows-msvc\release\mla.lib" cargo build --target=x86_64-pc-windows-msvc --release</Command>


### PR DESCRIPTION
Since Cargo 1.70, it is necessary to also link to `ntdll.lib` (see #173)

This PR:

- updates the bindings/C projects accordingly
- remove the `1.69` forced version in the CI tests