### PR TITLE
Introduces Hybrid key

### DIFF
--- a/mla/Cargo.toml
+++ b/mla/Cargo.toml
@@ -19,6 +19,7 @@ bitflags = { version = "2.1", default-features = false, features = ["serde"]}
 byteorder = { version = "1.3", default-features = false, features = ["std"] }
 serde = { version = "1", default-features = false, features = ["derive"] }
 bincode = { version = "1.3", default-features = false}
+serde-big-array = { version = "0.5.1", default-features = false }
 # Crypto needs
 # Version fixed due to avoid conflict dependencies with `aes`, `aes-ctr` and `ghash`
 generic-array = { version = "0.14", default-features = false}
@@ -32,6 +33,9 @@ x25519-dalek = { version = "2", default-features = false, features = ["zeroize",
 hkdf = { version = "0", default-features = false}
 sha2 = { version = "0", default-features = false}
 zeroize = { version = "1", default-features = false}
+# Post-quantum
+ml-kem = { version = "0.1.1", default-features = false }
+kem = {version = "0.3.0-pre.0", default-features = false }
 
 
 [dev-dependencies]

--- a/mla/src/crypto/hybrid.rs
+++ b/mla/src/crypto/hybrid.rs
@@ -1,0 +1,470 @@
+use crate::crypto::aesgcm::{ConstantTimeEq, Key, KEY_SIZE, NONCE_AES_SIZE, TAG_LENGTH};
+use crate::crypto::ecc::{derive_key as ecc_derive_key, DHKEMCipherText};
+use crate::errors::ConfigError;
+use crate::layers::encrypt::get_crypto_rng;
+use kem::{Decapsulate, Encapsulate};
+use ml_kem::{KemCore, MlKem1024};
+use rand::Rng;
+use rand_chacha::rand_core::CryptoRngCore;
+use serde::{Deserialize, Serialize};
+use serde_big_array::BigArray;
+use sha2::{Digest, Sha256};
+use x25519_dalek::{PublicKey as X25519PublicKey, StaticSecret as X25519StaticSecret};
+
+/// Represent a ML-KEM ciphertext
+type MLKEMCiphertext = [u8; 1568];
+
+const HYBRIDKEM_ASSOCIATED_DATA: &[u8; 0] = b"";
+
+/// Concatenation scheme to keep IND-CCA, proved in [1] and explained in [4]
+/// It is very similar to the one used by TLS [2] and IKE [3], and this kind of scheme
+/// follows ANSSI recommandations [5]
+///
+/// key = KDF(ss1 . ss2 . ct1 . ct2), with ss1 and ss2 the shared secrets and ct1 and ct2 the ciphertexts
+///
+/// [1] "F. Giacon, F. Heuer, and B. Poettering. Kem combiners, Cham, 2018"
+/// [2] https://datatracker.ietf.org/doc/draft-ietf-tls-hybrid-design/
+/// [3] https://datatracker.ietf.org/doc/html/rfc9370
+/// [4] https://eprint.iacr.org/2024/039
+/// [5] https://cyber.gouv.fr/en/publications/follow-position-paper-post-quantum-cryptography
+fn combine(
+    shared_secret1: &[u8],
+    shared_secret2: &[u8],
+    ciphertext1: &[u8],
+    ciphertext2: &[u8],
+) -> Key {
+    let mut hasher = Sha256::new();
+    hasher.update(shared_secret1);
+    hasher.update(shared_secret2);
+    hasher.update(ciphertext1);
+    hasher.update(ciphertext2);
+    hasher.finalize().into()
+    // TODO: Consider adding a HKDF, like some of the referenced sources
+}
+
+// ------- KEM implementation for a multi-recipient, hybrid, scheme -------
+//
+// Scheme 1: ECC, with X25519
+// Scheme 2: ML (post-quantum), with FIPS-203 ML-KEM (CRYSTALS Kyber 1024)
+//
+// Use `_ecc` and `_ml` naming rather than a generic approach (`_1``, `_2`)
+// to avoid confusion / prone-to-error code
+
+/// Per-recipient hybrid encapsulated key
+#[derive(Serialize, Deserialize)]
+struct HybridRecipientEncapsulatedKey {
+    /// Ciphertext for ML-KEM
+    #[serde(with = "BigArray")]
+    ct_ml: MLKEMCiphertext,
+    /// Wrapped (encrypted) version of the main key
+    /// - Algorithm: AES-GCM 256
+    /// - Key: hybrid shared secret
+    /// - Nonce: per-recipient
+    wrapped_key: [u8; KEY_SIZE],
+    /// Associated tag
+    tag: [u8; TAG_LENGTH],
+    /// Associated nonce
+    nonce: [u8; NONCE_AES_SIZE],
+}
+
+/// Key encapsulated for multiple recipient with hybrid cryptography
+/// Will be store in and load from the header
+#[derive(Serialize, Deserialize)]
+pub struct HybridMultiRecipientEncapsulatedKey {
+    /// Common ciphertext for DH-KEM (actually an ECC ephemeral public key)
+    ct_ecc: DHKEMCipherText,
+    /// Key wrapping for each recipient
+    recipients: Vec<HybridRecipientEncapsulatedKey>,
+}
+
+impl HybridMultiRecipientEncapsulatedKey {
+    /// Return the number of recipients' key
+    pub fn count_keys(&self) -> usize {
+        self.recipients.len()
+    }
+}
+
+/// Private key for hybrid cryptography, made of
+/// - a X25519 key, for ECC (pre-quantum) cryptography
+/// - a ML-KEM 1024 key, for post-quantum cryptography
+/// 
+/// Support KEM decapsulation
+#[derive(Clone)]
+pub struct HybridPrivateKey {
+    private_key_ecc: X25519StaticSecret,
+    private_key_ml: <MlKem1024 as KemCore>::DecapsulationKey,
+}
+
+impl Decapsulate<HybridMultiRecipientEncapsulatedKey, Key> for HybridPrivateKey {
+    type Error = ConfigError;
+
+    fn decapsulate(
+        &self,
+        encapsulated_key: &HybridMultiRecipientEncapsulatedKey,
+    ) -> Result<Key, Self::Error> {
+        // For each possible recipient, compute the candidate hybrid shared secret
+        let ss_ecc = ecc_derive_key(
+            &self.private_key_ecc,
+            &X25519PublicKey::from(encapsulated_key.ct_ecc),
+        )
+        .or(Err(ConfigError::ECIESComputationError))?;
+        for recipient in &encapsulated_key.recipients {
+            let ss_ml = self
+                .private_key_ml
+                .decapsulate(&recipient.ct_ml.into())
+                .or(Err(ConfigError::MLKEMComputationError))?;
+
+            let shared_secret =
+                combine(&ss_ecc, &ss_ml, &encapsulated_key.ct_ecc, &recipient.ct_ml);
+
+            // Unwrap the candidate key and check it using AES-GCM tag validation
+            let mut cipher = crate::crypto::aesgcm::AesGcm256::new(
+                &shared_secret,
+                &recipient.nonce,
+                HYBRIDKEM_ASSOCIATED_DATA,
+            )
+            .or(Err(ConfigError::KeyWrappingComputationError))?;
+            let mut decrypted_key = Key::default();
+            decrypted_key.copy_from_slice(&recipient.wrapped_key);
+            let tag = cipher.decrypt(&mut decrypted_key);
+            if tag.ct_eq(&recipient.tag).unwrap_u8() == 1 {
+                return Ok(decrypted_key);
+            }
+        }
+
+        // No candidate key found
+        Err(ConfigError::PrivateKeyNotFound)
+    }
+}
+
+/// Public key for hybrid cryptography, made of
+/// - a X25519 key, for ECC (pre-quantum) cryptography
+/// - a ML-KEM 1024 key, for post-quantum cryptography
+#[derive(Clone)]
+pub struct HybridPublicKey {
+    public_key_ecc: X25519PublicKey,
+    public_key_ml: <MlKem1024 as KemCore>::EncapsulationKey,
+}
+
+/// Public keys for multiple recipients, used for hybrid cryptography
+/// 
+/// Support KEM encapsulation
+#[derive(Default)]
+pub(crate) struct HybridMultiRecipientsPublicKeys {
+    pub(crate) keys: Vec<HybridPublicKey>,
+}
+
+impl Encapsulate<HybridMultiRecipientEncapsulatedKey, Key> for HybridMultiRecipientsPublicKeys {
+    type Error = ConfigError;
+
+    fn encapsulate(
+        &self,
+        csprng: &mut impl CryptoRngCore,
+    ) -> Result<(HybridMultiRecipientEncapsulatedKey, Key), Self::Error> {
+        // Generate the final Key -- the one each recipient will finally retrieve
+        let key = csprng.gen::<Key>();
+
+        // A `StaticSecret` is used instead of an `EphemeralSecret` to allow for
+        // multiple diffie-hellman computation
+        let ephemeral = X25519StaticSecret::from(csprng.gen::<[u8; 32]>());
+        let ct_ecc = X25519PublicKey::from(&ephemeral);
+
+        let mut recipients = Vec::new();
+        for recipient in &self.keys {
+            // Compute the ECC shared secret
+            let ss_ecc = ecc_derive_key(&ephemeral, &recipient.public_key_ecc)
+                .or(Err(ConfigError::ECIESComputationError))?;
+
+            // Compute the ML-KEM shared secret
+            let (ct_ml, ss_ml) = &recipient
+                .public_key_ml
+                .encapsulate(csprng)
+                .or(Err(ConfigError::MLKEMComputationError))?;
+
+            // Combine them to obtain the hybrid shared secret
+            let ss_hybrid = combine(&ss_ecc, ss_ml, ct_ecc.as_bytes(), ct_ml);
+
+            // Wrap the final key
+            let nonce = csprng.gen::<[u8; NONCE_AES_SIZE]>();
+            let mut cipher = crate::crypto::aesgcm::AesGcm256::new(
+                &ss_hybrid,
+                &nonce,
+                HYBRIDKEM_ASSOCIATED_DATA,
+            )
+            .or(Err(ConfigError::KeyWrappingComputationError))?;
+            let mut wrapped_key = Key::default();
+            wrapped_key.copy_from_slice(&key);
+            cipher.encrypt(&mut wrapped_key);
+            let mut tag = [0u8; TAG_LENGTH];
+            tag.copy_from_slice(&cipher.into_tag());
+
+            recipients.push(HybridRecipientEncapsulatedKey {
+                ct_ml: (*ct_ml).into(),
+                wrapped_key,
+                tag,
+                nonce,
+            });
+        }
+
+        Ok((
+            HybridMultiRecipientEncapsulatedKey {
+                ct_ecc: ct_ecc.to_bytes(),
+                recipients,
+            },
+            key,
+        ))
+    }
+}
+
+/// Generate an Hybrid key pair using the provided csprng
+pub fn generate_keypair_from_rng(
+    mut csprng: impl CryptoRngCore,
+) -> (HybridPrivateKey, HybridPublicKey) {
+    let private_key_ecc = X25519StaticSecret::random_from_rng(&mut csprng);
+    let public_key_ecc = X25519PublicKey::from(&private_key_ecc);
+    let (private_key_ml, public_key_ml) = MlKem1024::generate(&mut csprng);
+    (
+        HybridPrivateKey {
+            private_key_ecc,
+            private_key_ml,
+        },
+        HybridPublicKey {
+            public_key_ecc,
+            public_key_ml,
+        },
+    )
+}
+
+/// Generate an Hybrid key pair using a CSPRNG
+pub fn generate_keypair() -> (HybridPrivateKey, HybridPublicKey) {
+    generate_keypair_from_rng(get_crypto_rng())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Read;
+
+    use brotli;
+    use rand::SeedableRng;
+    use rand_chacha::ChaChaRng;
+    use std::collections::HashSet;
+
+    use super::*;
+
+    /// Test that combine indeed depends on each input
+    #[test]
+    fn test_combine() {
+        let shared_secret1 = vec![1, 2, 3];
+        let shared_secret1_mod = vec![0xff, 2, 3];
+        let shared_secret2 = vec![4, 5, 6];
+        let shared_secret2_mod = vec![0xff, 5, 6];
+        let ciphertext1 = vec![7, 8, 9];
+        let ciphertext1_mod = vec![0xff, 8, 9];
+        let ciphertext2 = vec![10, 11, 12];
+        let ciphertext2_mod = vec![0xff, 11, 12];
+
+        // Cartesian product of all possibilities
+        let res1 = combine(&shared_secret1, &shared_secret2, &ciphertext1, &ciphertext2);
+        let res2 = combine(
+            &shared_secret1_mod,
+            &shared_secret2,
+            &ciphertext1,
+            &ciphertext2,
+        );
+        let res3 = combine(
+            &shared_secret1,
+            &shared_secret2_mod,
+            &ciphertext1,
+            &ciphertext2,
+        );
+        let res4 = combine(
+            &shared_secret1,
+            &shared_secret2,
+            &ciphertext1_mod,
+            &ciphertext2,
+        );
+        let res5 = combine(
+            &shared_secret1,
+            &shared_secret2,
+            &ciphertext1,
+            &ciphertext2_mod,
+        );
+
+        // Ensure they are all unique
+        let unique_results: HashSet<_> = vec![res1, res2, res3, res4, res5].into_iter().collect();
+        assert_eq!(unique_results.len(), 5);
+    }
+
+    /// Test the encapsulation and decapsulation of an hybrid key
+    #[test]
+    fn test_encapsulate_decapsulate() {
+        let mut csprng = ChaChaRng::from_entropy();
+
+        // Create public and private keys
+        let private_key_ecc = X25519StaticSecret::from(csprng.gen::<[u8; 32]>());
+        let public_key_ecc = X25519PublicKey::from(&private_key_ecc);
+        let (private_key_ml, public_key_ml) = MlKem1024::generate(&mut csprng);
+
+        // Create hybrid public and private keys
+        let hybrid_private_key = HybridPrivateKey {
+            private_key_ecc,
+            private_key_ml,
+        };
+        let hybrid_public_key = HybridPublicKey {
+            public_key_ecc,
+            public_key_ml,
+        };
+
+        // Create hybrid multi-recipient encapsulated keys
+        let hybrid_multi_recipient_keys = HybridMultiRecipientsPublicKeys {
+            keys: vec![hybrid_public_key],
+        };
+
+        // Encapsulate a key
+        let (encapsulated_keys, key_encap) = hybrid_multi_recipient_keys
+            .encapsulate(&mut csprng)
+            .unwrap();
+
+        // Decapsulate the key
+        let key_decap = hybrid_private_key.decapsulate(&encapsulated_keys).unwrap();
+
+        // Ensure both key match
+        assert_eq!(key_encap, key_decap);
+    }
+
+    const NB_RECIPIENT: u32 = 10;
+    /// Test the encapsulation and decapsulation of an hybrid key for several recipients
+    #[test]
+    fn test_encapsulate_decapsulate_multi() {
+        let mut csprng = ChaChaRng::from_entropy();
+
+        let mut hybrid_multi_recipient_public_keys =
+            HybridMultiRecipientsPublicKeys { keys: Vec::new() };
+        let mut hybrid_multi_recipient_private_keys = Vec::new();
+        for _ in 0..NB_RECIPIENT {
+            // Create public and private keys
+            let private_key_ecc = X25519StaticSecret::from(csprng.gen::<[u8; 32]>());
+            let public_key_ecc = X25519PublicKey::from(&private_key_ecc);
+            let (private_key_ml, public_key_ml) = MlKem1024::generate(&mut csprng);
+
+            // Create hybrid public and private keys
+            let hybrid_private_key = HybridPrivateKey {
+                private_key_ecc,
+                private_key_ml,
+            };
+            let hybrid_public_key = HybridPublicKey {
+                public_key_ecc,
+                public_key_ml,
+            };
+
+            hybrid_multi_recipient_public_keys
+                .keys
+                .push(hybrid_public_key);
+            hybrid_multi_recipient_private_keys.push(hybrid_private_key);
+        }
+
+        // Encapsulate a key
+        let (encapsulated_keys, key_encap) = hybrid_multi_recipient_public_keys
+            .encapsulate(&mut csprng)
+            .unwrap();
+
+        // Decapsulate the key for each recipient
+        for private_key in &hybrid_multi_recipient_private_keys {
+            let key_decap = private_key.decapsulate(&encapsulated_keys).unwrap();
+
+            // Check the key is the expected one
+            assert_eq!(key_encap, key_decap);
+        }
+    }
+
+    /// Test cryprographic materials (including the encapsulated key) for entropy
+    #[test]
+    fn test_encapsulated_key_entropy() {
+        let mut csprng = ChaChaRng::from_entropy();
+
+        // Create initial materials
+        let private_key_ecc = X25519StaticSecret::from(csprng.gen::<[u8; 32]>());
+        let public_key_ecc = X25519PublicKey::from(&private_key_ecc);
+        let (_private_key_ml, public_key_ml) = MlKem1024::generate(&mut csprng);
+        let hybrid_public_key = HybridPublicKey {
+            public_key_ecc,
+            public_key_ml,
+        };
+        let hybrid_multi_recipient_keys = HybridMultiRecipientsPublicKeys {
+            keys: vec![hybrid_public_key],
+        };
+
+        // Encapsulate a key
+        let (encapsulated_keys, key_encap) = hybrid_multi_recipient_keys
+            .encapsulate(&mut csprng)
+            .unwrap();
+        let recipient = &encapsulated_keys.recipients[0];
+
+        // Ensure materials have enough entropy
+        // This is a naive check, using compression, to avoid naive bugs
+        let materials: Vec<&[u8]> = vec![
+            &key_encap,
+            &recipient.nonce,
+            &recipient.tag,
+            &recipient.wrapped_key,
+        ];
+        for material in materials {
+            let mut compressed = brotli::CompressorReader::new(material, 0, 0, 0);
+            let mut compressed_data = Vec::new();
+            compressed.read_to_end(&mut compressed_data).unwrap();
+
+            assert!(compressed_data.len() >= material.len());
+        }
+    }
+
+    /// Test the generation of a key pair
+    #[test]
+    fn test_generate_keypair() {
+        let (private_key, public_key) = generate_keypair();
+
+        // Ensure the ECC private key correspond to the ECC public key
+        let public_key_ecc = X25519PublicKey::from(&private_key.private_key_ecc);
+        assert_eq!(public_key_ecc, public_key.public_key_ecc);
+
+        // Ensure the ML private key correspond to the ML public key
+        let mut rng = ChaChaRng::from_entropy();
+        let (encap, key) = public_key.public_key_ml.encapsulate(&mut rng).unwrap();
+        let key_decap = private_key.private_key_ml.decapsulate(&encap).unwrap();
+        assert_eq!(key, key_decap);
+    }
+
+    #[test]
+    fn test_generate_keypair_from_rng() {
+        // Ensure reproductability
+        let mut rng = ChaChaRng::seed_from_u64(0);
+        let (private_key, public_key) = generate_keypair_from_rng(&mut rng);
+        let mut rng = ChaChaRng::seed_from_u64(0);
+        let (private_key2, public_key2) = generate_keypair_from_rng(&mut rng);
+
+        assert_eq!(
+            private_key.private_key_ecc.to_bytes(),
+            private_key2.private_key_ecc.to_bytes()
+        );
+        assert_eq!(private_key.private_key_ml, private_key2.private_key_ml);
+        assert_eq!(
+            public_key.public_key_ecc.as_bytes(),
+            public_key2.public_key_ecc.as_bytes()
+        );
+        assert_eq!(public_key.public_key_ml, public_key2.public_key_ml);
+
+        // Ensure keypair are different
+        let mut rng = ChaChaRng::seed_from_u64(1);
+        let (private_key3, public_key3) = generate_keypair_from_rng(&mut rng);
+
+        assert_ne!(
+            private_key.private_key_ecc.to_bytes(),
+            private_key3.private_key_ecc.to_bytes()
+        );
+        assert_ne!(private_key.private_key_ml, private_key3.private_key_ml);
+        assert_ne!(
+            public_key.public_key_ecc.as_bytes(),
+            public_key3.public_key_ecc.as_bytes()
+        );
+        assert_ne!(public_key.public_key_ml, public_key3.public_key_ml);
+    }
+}

--- a/mla/src/crypto/hybrid.rs
+++ b/mla/src/crypto/hybrid.rs
@@ -87,7 +87,7 @@ impl HybridMultiRecipientEncapsulatedKey {
 /// Private key for hybrid cryptography, made of
 /// - a X25519 key, for ECC (pre-quantum) cryptography
 /// - a ML-KEM 1024 key, for post-quantum cryptography
-/// 
+///
 /// Support KEM decapsulation
 #[derive(Clone)]
 pub struct HybridPrivateKey {
@@ -147,7 +147,7 @@ pub struct HybridPublicKey {
 }
 
 /// Public keys for multiple recipients, used for hybrid cryptography
-/// 
+///
 /// Support KEM encapsulation
 #[derive(Default)]
 pub(crate) struct HybridMultiRecipientsPublicKeys {

--- a/mla/src/crypto/mod.rs
+++ b/mla/src/crypto/mod.rs
@@ -1,3 +1,4 @@
 pub mod aesgcm;
 pub mod ecc;
 pub mod hash;
+pub mod hybrid;

--- a/mla/src/errors.rs
+++ b/mla/src/errors.rs
@@ -192,10 +192,13 @@ pub enum ConfigError {
     EncryptionKeyIsMissing,
     PrivateKeyNotSet,
     PrivateKeyNotFound,
+    MLKEMComputationError,
     ECIESComputationError,
     KeyCommitmentComputationError,
     /// The encrypted key commitment does not correspond to the key commitment chain
     KeyCommitmentCheckingError,
+    /// Error while wrapping or unwrapping the encryption key
+    KeyWrappingComputationError,
 }
 
 impl fmt::Display for ConfigError {

--- a/mla/src/layers/encrypt.rs
+++ b/mla/src/layers/encrypt.rs
@@ -1,8 +1,11 @@
 use crate::crypto::aesgcm::{
     AesGcm256, ConstantTimeEq, Key, Nonce, Tag, KEY_COMMITMENT_SIZE, TAG_LENGTH,
 };
-use crate::crypto::ecc::{retrieve_key, store_key_for_multi_recipients, MultiRecipientPersistent};
 
+use crate::crypto::hybrid::{
+    HybridMultiRecipientEncapsulatedKey, HybridMultiRecipientsPublicKeys, HybridPrivateKey,
+    HybridPublicKey,
+};
 use crate::layers::traits::{
     InnerWriterTrait, InnerWriterType, LayerFailSafeReader, LayerReader, LayerWriter,
 };
@@ -12,9 +15,9 @@ use std::io::{BufReader, Cursor, Read, Seek, SeekFrom, Write};
 
 use crate::config::{ArchiveReaderConfig, ArchiveWriterConfig};
 use crate::errors::ConfigError;
+use kem::{Decapsulate, Encapsulate};
 use rand::{Rng, SeedableRng};
 use rand_chacha::{rand_core::CryptoRngCore, ChaChaRng};
-use x25519_dalek::{PublicKey, StaticSecret};
 
 use serde::{Deserialize, Deserializer, Serialize};
 use zeroize::Zeroize;
@@ -24,6 +27,8 @@ use super::traits::InnerReaderTrait;
 const CIPHER_BUF_SIZE: u64 = 4096;
 // This is the size of the nonce taken as input
 const NONCE_SIZE: usize = 8;
+/// Type standing for the unique nonce per-archive
+type ArchiveNonce = [u8; NONCE_SIZE];
 const CHUNK_SIZE: u64 = 128 * 1024;
 
 const ASSOCIATED_DATA: &[u8; 0] = b"";
@@ -39,7 +44,7 @@ const ASSOCIATED_DATA: &[u8; 0] = b"";
 ///
 /// Inspired from the construction in TLS or STREAM from "Online
 /// Authenticated-Encryption and its Nonce-Reuse Misuse-Resistance"
-fn build_nonce(nonce_prefix: [u8; NONCE_SIZE], current_ctr: u32) -> Nonce {
+fn build_nonce(nonce_prefix: ArchiveNonce, current_ctr: u32) -> Nonce {
     // This is the Nonce as expected by AesGcm
     let mut nonce = Nonce::default();
     nonce[..NONCE_SIZE].copy_from_slice(&nonce_prefix);
@@ -57,7 +62,7 @@ const KEY_COMMITMENT_CHAIN: &[u8; KEY_COMMITMENT_SIZE] =
 /// Encrypt the hardcoded `KEY_COMMITMENT_CHAIN` with the given key and nonce
 fn build_key_commitment_chain(
     key: &Key,
-    nonce: &[u8; NONCE_SIZE],
+    nonce: &ArchiveNonce,
 ) -> Result<KeyCommitmentAndTag, Error> {
     let mut key_commitment = [0u8; KEY_COMMITMENT_SIZE];
     key_commitment.copy_from_slice(KEY_COMMITMENT_CHAIN);
@@ -73,7 +78,7 @@ fn build_key_commitment_chain(
 
 fn check_key_commitment(
     key: &Key,
-    nonce: &[u8; NONCE_SIZE],
+    nonce: &ArchiveNonce,
     commitment: &KeyCommitmentAndTag,
 ) -> Result<(), ConfigError> {
     let mut key_commitment = commitment.key_commitment;
@@ -104,6 +109,7 @@ struct KeyCommitmentAndTag {
 // -> Serialize as [u8; 32][u8; 32]
 // A Vec<u8> could also be used, but using array avoid having creating arbitrary sized vectors
 // that early in the process
+// TODO: use serde-big-array
 impl Serialize for KeyCommitmentAndTag {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -137,7 +143,7 @@ impl<'de> Deserialize<'de> for KeyCommitmentAndTag {
 }
 
 /// Return a Cryptographic random number generator
-fn get_crypto_rng() -> impl CryptoRngCore {
+pub(crate) fn get_crypto_rng() -> impl CryptoRngCore {
     // Use OsRng from crate rand, that uses getrandom() from crate getrandom.
     // getrandom provides implementations for many systems, listed on
     // https://docs.rs/getrandom/0.1.14/getrandom/
@@ -163,14 +169,13 @@ fn get_crypto_rng() -> impl CryptoRngCore {
 /// Part of this data must be kept secret and drop as soon as possible
 pub(crate) struct InternalEncryptionConfig {
     pub(crate) key: Key,
-    pub(crate) nonce: [u8; NONCE_SIZE],
+    pub(crate) nonce: ArchiveNonce,
 }
 
-impl Default for InternalEncryptionConfig {
-    fn default() -> Self {
+impl InternalEncryptionConfig {
+    fn from(key: Key) -> Self {
         let mut csprng = get_crypto_rng();
-        let key = csprng.gen::<Key>();
-        let nonce = csprng.gen::<[u8; NONCE_SIZE]>();
+        let nonce = csprng.gen::<ArchiveNonce>();
 
         Self { key, nonce }
     }
@@ -180,9 +185,9 @@ impl Default for InternalEncryptionConfig {
 #[derive(Serialize, Deserialize)]
 pub struct EncryptionPersistentConfig {
     /// Key-wrapping for each recipients
-    pub multi_recipient: MultiRecipientPersistent,
+    pub multi_recipient: HybridMultiRecipientEncapsulatedKey,
     /// Nonce for the archive AES-GCM
-    nonce: [u8; NONCE_SIZE],
+    nonce: ArchiveNonce,
     /// Encrypted version of the hardcoded `KEY_COMMITMENT_CHAIN`
     key_commitment: KeyCommitmentAndTag,
 }
@@ -191,35 +196,32 @@ pub struct EncryptionPersistentConfig {
 /// ArchiveWriterConfig specific configuration for the Encryption, to let API users specify encryption options
 pub struct EncryptionConfig {
     /// Public keys of recipients
-    ecc_keys: Vec<PublicKey>,
+    public_keys: HybridMultiRecipientsPublicKeys,
 }
 
 impl EncryptionConfig {
     /// Consistency check
     pub fn check(&self) -> Result<(), ConfigError> {
-        if self.ecc_keys.is_empty() {
+        if self.public_keys.keys.is_empty() {
             Err(ConfigError::NoRecipients)
         } else {
             Ok(())
         }
     }
 
-    /// Create a persistent version, to be reloaded, of the configuration
-    /// This method also create the cryptographic material, so it can only be called once
+    /// Create a persistent version of the configuration to be reloaded
+    ///    and the internal configuration, containing the cryptographic material
+    ///
+    /// This material is created for the current recipients, and several call to this function
+    /// will results in several materials
     pub(crate) fn to_persistent(
         &self,
     ) -> Result<(EncryptionPersistentConfig, InternalEncryptionConfig), ConfigError> {
-        // This will generate the main encrypt layer key & nonce
-        let cryptographic_material = InternalEncryptionConfig::default();
+        // Generate then encapsulate the main key for each recipients
+        let (multi_recipient, key) = self.public_keys.encapsulate(&mut get_crypto_rng())?;
 
-        // Store a wrapped version of the key for each recipient
-        // As this function call be call only once, recipient list can't be changed after
-        let multi_recipient = store_key_for_multi_recipients(
-            &self.ecc_keys,
-            &cryptographic_material.key,
-            &mut get_crypto_rng(),
-        )
-        .or(Err(ConfigError::ECIESComputationError))?;
+        // Generate the main encrypt layer nonce and keep the main key for internal use
+        let cryptographic_material = InternalEncryptionConfig::from(key);
 
         // Add a key commitment
         let key_commitment =
@@ -241,8 +243,8 @@ impl EncryptionConfig {
 
 impl ArchiveWriterConfig {
     /// Set public keys to use
-    pub fn add_public_keys(&mut self, keys: &[PublicKey]) -> &mut ArchiveWriterConfig {
-        self.encrypt.ecc_keys.extend_from_slice(keys);
+    pub fn add_public_keys(&mut self, keys: &[HybridPublicKey]) -> &mut ArchiveWriterConfig {
+        self.encrypt.public_keys.keys.extend_from_slice(keys);
         self
     }
 }
@@ -250,9 +252,10 @@ impl ArchiveWriterConfig {
 #[derive(Default)]
 pub struct EncryptionReaderConfig {
     /// Private key(s) to use
-    private_keys: Vec<StaticSecret>,
+    private_keys: Vec<HybridPrivateKey>,
     /// Symmetric encryption key and nonce, if decrypted successfully from header
-    encrypt_parameters: Option<(Key, [u8; NONCE_SIZE])>,
+    // TODO: split in two, like InternalEncryptionConfig
+    encrypt_parameters: Option<(Key, ArchiveNonce)>,
 }
 
 impl EncryptionReaderConfig {
@@ -265,38 +268,30 @@ impl EncryptionReaderConfig {
             return Err(ConfigError::PrivateKeyNotSet);
         }
         for private_key in &self.private_keys {
-            match retrieve_key(&config.multi_recipient, private_key) {
-                Ok(Some(key)) => {
-                    self.encrypt_parameters = Some((key, config.nonce));
-                    break;
-                }
-                _ => {
-                    continue;
-                }
+            if let Ok(key) = private_key.decapsulate(&config.multi_recipient) {
+                self.encrypt_parameters = Some((key, config.nonce));
+                break;
             };
         }
 
-        if let Some((key, nonce)) = &self.encrypt_parameters {
-            // A key has been found, check if it is the one expected
-            check_key_commitment(key, nonce, &config.key_commitment)
-                .or(Err(ConfigError::KeyCommitmentCheckingError))?;
-        } else {
-            return Err(ConfigError::PrivateKeyNotFound);
-        }
+        let (key, nonce) = &self
+            .encrypt_parameters
+            .ok_or(ConfigError::PrivateKeyNotFound)?;
 
-        Ok(())
+        // A key has been found, check if it is the one expected
+        check_key_commitment(key, nonce, &config.key_commitment)
     }
 }
 
 impl ArchiveReaderConfig {
     /// Set private key to use
-    pub fn add_private_keys(&mut self, keys: &[StaticSecret]) -> &mut ArchiveReaderConfig {
+    pub fn add_private_keys(&mut self, keys: &[HybridPrivateKey]) -> &mut ArchiveReaderConfig {
         self.encrypt.private_keys.extend_from_slice(keys);
         self
     }
 
     /// Retrieve key and nonce used for encryption
-    pub fn get_encrypt_parameters(&self) -> Option<(Key, [u8; NONCE_SIZE])> {
+    pub fn get_encrypt_parameters(&self) -> Option<(Key, ArchiveNonce)> {
         self.encrypt.encrypt_parameters
     }
 }
@@ -309,7 +304,7 @@ pub(crate) struct EncryptionLayerWriter<'a, W: 'a + InnerWriterTrait> {
     /// Symmetric encryption Key
     key: Key,
     /// Symmetric encryption nonce prefix, see `build_nonce`
-    nonce_prefix: [u8; NONCE_SIZE],
+    nonce_prefix: ArchiveNonce,
     current_chunk_offset: u64,
     current_ctr: u32,
 }
@@ -408,7 +403,7 @@ pub struct EncryptionLayerReader<'a, R: Read + Seek> {
     inner: Box<dyn 'a + LayerReader<'a, R>>,
     cipher: AesGcm256,
     key: Key,
-    nonce: [u8; NONCE_SIZE],
+    nonce: ArchiveNonce,
     chunk_cache: Cursor<Vec<u8>>,
     /// Current chunk number in the data.
     /// Note: the actual chunk number used in the cipher is offseted by FIRST_DATA_CHUNK_NUMBER
@@ -601,7 +596,7 @@ pub struct EncryptionLayerFailSafeReader<'a, R: Read> {
     inner: Box<dyn 'a + LayerFailSafeReader<'a, R>>,
     cipher: AesGcm256,
     key: Key,
-    nonce: [u8; NONCE_SIZE],
+    nonce: ArchiveNonce,
     current_chunk_number: u32,
     current_chunk_offset: u64,
 }
@@ -686,7 +681,7 @@ mod tests {
 
     static FAKE_FILE: [u8; 26] = *b"abcdefghijklmnopqrstuvwxyz";
     static KEY: Key = [2u8; KEY_SIZE];
-    static NONCE: [u8; NONCE_SIZE] = [3u8; NONCE_SIZE];
+    static NONCE: ArchiveNonce = [3u8; NONCE_SIZE];
 
     fn encrypt_write(file: Vec<u8>) -> Vec<u8> {
         // Instantiate a EncryptionLayerWriter and fill it with FAKE_FILE
@@ -854,7 +849,7 @@ mod tests {
     fn build_key_commitment_chain_test() {
         // Build the encrypted key commitment chain
         let key: Key = [1u8; KEY_SIZE];
-        let nonce: [u8; NONCE_SIZE] = [2u8; NONCE_SIZE];
+        let nonce: ArchiveNonce = [2u8; NONCE_SIZE];
         let result = build_key_commitment_chain(&key, &nonce);
         assert!(result.is_ok());
         let key_commitment_and_tag = result.unwrap();
@@ -872,7 +867,7 @@ mod tests {
     fn check_key_commitment_test() {
         // Build the encrypted key commitment chain
         let key: Key = [1u8; KEY_SIZE];
-        let nonce: [u8; NONCE_SIZE] = [2u8; NONCE_SIZE];
+        let nonce: ArchiveNonce = [2u8; NONCE_SIZE];
         let result = build_key_commitment_chain(&key, &nonce);
         assert!(result.is_ok());
         let key_commitment_and_tag = result.unwrap();


### PR DESCRIPTION
Partially implements #195 

:warning: This PR contains breaking changes. In particular, a new type of key is used. `mlar` and ASN.1 parsers will be updated in future PR

This PR:

- Introduces hybrid PQC, based on `ml-kem` providing a FIPS-203 implementation
- Switch the key creation inside MLA from ECC to Hybrid PQC
- Remove the no-more-used code from ECC
- Comment some tests in MLA, because they require ASN.1 parsing