### PR TITLE
Allow unauthenticated data

### DIFF
--- a/mla/src/errors.rs
+++ b/mla/src/errors.rs
@@ -92,7 +92,12 @@ impl From<bincode::ErrorKind> for Error {
 
 impl From<Error> for io::Error {
     fn from(error: Error) -> Self {
-        io::Error::new(io::ErrorKind::Other, format!("{error}"))
+        match error {
+            // On IOError, unwrap it (MLAError(IOError(err))) -> err
+            Error::IOError(err) => err,
+            // Otherwise, use a generic construction
+            _ => io::Error::new(io::ErrorKind::Other, format!("{error}"))
+        }
     }
 }
 

--- a/mla/src/errors.rs
+++ b/mla/src/errors.rs
@@ -96,7 +96,7 @@ impl From<Error> for io::Error {
             // On IOError, unwrap it (MLAError(IOError(err))) -> err
             Error::IOError(err) => err,
             // Otherwise, use a generic construction
-            _ => io::Error::new(io::ErrorKind::Other, format!("{error}"))
+            _ => io::Error::new(io::ErrorKind::Other, format!("{error}")),
         }
     }
 }

--- a/mla/src/layers/encrypt.rs
+++ b/mla/src/layers/encrypt.rs
@@ -132,7 +132,7 @@ impl ArchiveWriterConfig {
 
 /// FailSafeReader decryption mode
 #[derive(Default, Clone, Copy)]
-pub enum FailSafeReaderDecryptionMode {
+enum FailSafeReaderDecryptionMode {
     /// Returns only the data that have been authenticated on decryption
     #[default]
     OnlyAuthenticatedData,
@@ -187,6 +187,18 @@ impl ArchiveReaderConfig {
     /// Retrieve key and nonce used for encryption
     pub fn get_encrypt_parameters(&self) -> Option<(Key, [u8; NONCE_SIZE])> {
         self.encrypt.encrypt_parameters
+    }
+
+    /// Set the FailSafeReader decryption mode to return only authenticated data (default)
+    pub fn failsafe_return_only_authenticated_data(&mut self) -> &mut ArchiveReaderConfig {
+        self.encrypt.failsafe_mode = FailSafeReaderDecryptionMode::OnlyAuthenticatedData;
+        self
+    }
+
+    /// Set the FailSafeReader decryption mode to return all data, even if not authenticated
+    pub fn failsafe_return_data_even_unauthenticated(&mut self) -> &mut ArchiveReaderConfig {
+        self.encrypt.failsafe_mode = FailSafeReaderDecryptionMode::DataEvenUnauthenticated;
+        self
     }
 }
 


### PR DESCRIPTION
Fix #167 

Credits @extiop 

This PR:

- change the default behavior of `FailSafeReader` to return only authenticated data
- add a possibility to have the old behavior (returning unauthenticated data)
- add a `--allow-unauthenticated-data` flag to `mlar repair` to enable this flag (**this is not recommended**)