### PR TITLE
Fix regarding incomplete repaired archive

### DIFF
--- a/mla/src/layers/compress.rs
+++ b/mla/src/layers/compress.rs
@@ -737,258 +737,221 @@ impl<'a, W: 'a + InnerWriterTrait> Write for CompressionLayerWriter<'a, W> {
 
 // ---------- Fail-Safe Reader ----------
 
-/// Internal state for the `CompressionLayerFailSafeReader`
-enum CompressionLayerFailSafeReaderState<R: Read> {
-    /// Ready contains the real inner destination
-    /// Only used for the initialization
-    Ready(R),
-    /// Inside a decompression stream
-    InData {
-        /// While decompressing, one doesn't know in advance the number of compressed bytes
-        /// As a result, the following is done:
-        /// 1. read from the source inside a buffer
-        /// 2. decompress the data from the buffer
-        ///     - if there is still data to decompress, go to 1.
-        ///     - if this is the end of the stream, continue to 3.
-        /// 3. the decompressor may have read too many byte, ie. `[end of stream n-1][start of stream n]`
-        ///    `                                                                     ^                 ^
-        ///    `                                                                 `input_offset`    last read position
-        /// 4. rewind, using the cache, to `input_offset`
-        ///
-        /// A cache must be used, as the source is `Read` but not `Seek`.
-        /// `input_offset` is guaranted to be in the cache because it must be in the decompressor working buffer,
-        /// and the working buffer is contained in the cache (in the worst case, it is the whole cache)
-        ///
-        /// Cache management:
-        /// ```ascii
-        ///                cache_filled_offset
-        ///                        v
-        /// cache: [................    ]
-        ///            ^
-        ///        read_offset
-        /// ```
-        /// Data read from the source, not yet used
-        /// Invariant:
-        ///     - `cache.len() == FAIL_SAFE_BUFFER_SIZE` (cache always allocated)
-        cache: Vec<u8>,
-        /// Bytes valid in the cache : [0..`cache_filled_offset`[ (0 -> no valid data)
-        cache_filled_offset: usize,
-        /// Next offset to read from the cache
-        /// Invariant:
-        ///     - `read_offset <= cache_filled_offset`
-        read_offset: usize,
-        /// Internal decompressor state
-        state: Box<BrotliState<StandardAlloc, StandardAlloc, StandardAlloc>>,
-        /// Number of bytes decompressed and returned for the current stream
-        uncompressed_read: u32,
-        /// Inner layer (data source)
-        inner: R,
-    },
-    /// Empty is a placeholder to allow state replacement
-    Empty,
-}
-
-impl<R: Read> CompressionLayerFailSafeReaderState<R> {
-    fn into_inner(self) -> R {
-        match self {
-            Self::InData { inner, .. } | Self::Ready(inner) => inner,
-            // `panic!` explicitly called to avoid propagating an error which
-            // must never happens (ie, calling `into_inner` in an inconsistent
-            // internal state)
-            Self::Empty => panic!("[Reader] Empty type to inner is impossible"),
-        }
-    }
-}
-
 pub struct CompressionLayerFailSafeReader<'a, R: 'a + Read> {
-    state: CompressionLayerFailSafeReaderState<Box<dyn 'a + LayerFailSafeReader<'a, R>>>,
+    /// While decompressing, one doesn't know in advance the number of compressed bytes
+    /// As a result, the following is done:
+    /// 1. read from the source inside a buffer
+    /// 2. decompress the data from the buffer
+    ///     - if there is still data to decompress, go to 1.
+    ///     - if this is the end of the stream, continue to 3.
+    /// 3. the decompressor may have read too many byte, ie. `[end of stream n-1][start of stream n]`
+    ///    `                                                                     ^                 ^
+    ///    `                                                                 `input_offset`    last read position
+    /// 4. rewind, using the cache, to `input_offset`
+    ///
+    /// A cache must be used, as the source is `Read` but not `Seek`.
+    /// `input_offset` is guaranted to be in the cache because it must be in the decompressor working buffer,
+    /// and the working buffer is contained in the cache (in the worst case, it is the whole cache)
+    ///
+    /// Cache management:
+    /// ```ascii
+    ///                cache_filled_offset
+    ///                        v
+    /// cache: [................    ]
+    ///            ^
+    ///        read_offset
+    /// ```
+    /// Data read from the source, not yet used
+    cache: Vec<u8>,
+    /// Bytes valid in the cache : [0..`cache_filled_offset`[ (0 -> no valid data)
+    cache_filled_offset: usize,
+    /// Next offset to read from the cache
+    /// Invariant:
+    ///     - `read_offset <= cache_filled_offset`
+    read_offset: usize,
+    /// Internal decompressor state
+    brotli_state: Box<BrotliState<StandardAlloc, StandardAlloc, StandardAlloc>>,
+    /// Number of bytes decompressed and returned for the current stream
+    uncompressed_read: u32,
+    /// Inner layer (data source)
+    inner: Box<dyn 'a + LayerFailSafeReader<'a, R>>,
 }
 
 impl<'a, R: 'a + Read> CompressionLayerFailSafeReader<'a, R> {
-    pub fn new(inner: Box<dyn 'a + LayerFailSafeReader<'a, R>>) -> Result<Self, Error> {
-        Ok(Self {
-            state: CompressionLayerFailSafeReaderState::Ready(inner),
-        })
+    pub fn new(inner: Box<dyn 'a + LayerFailSafeReader<'a, R>>) -> Self {
+        CompressionLayerFailSafeReader {
+            cache: vec![0u8; FAIL_SAFE_BUFFER_INITIAL_SIZE],
+            read_offset: 0,
+            cache_filled_offset: 0,
+            brotli_state: Box::new(BrotliState::new(
+                StandardAlloc::default(),
+                StandardAlloc::default(),
+                StandardAlloc::default(),
+            )),
+            uncompressed_read: 0,
+            inner,
+        }
+    }
+
+    fn fail_safe_decompress_stream(
+        &mut self,
+        mut args: FailSafeDecompressStreamParams,
+        buf: &mut [u8],
+    ) -> io::Result<usize> {
+        match brotli::BrotliDecompressStream(
+            &mut args.available_in,
+            &mut args.input_offset,
+            &self.cache[self.read_offset..self.cache_filled_offset],
+            &mut args.available_out,
+            &mut args.output_offset,
+            buf,
+            &mut args.written,
+            &mut self.brotli_state,
+        ) {
+            brotli::BrotliResult::ResultSuccess => {
+                // End of stream reached
+
+                // Rewind the cache to the actual start of the new block
+                // input_offset \in [0; cache_filled_offset - read_offset[
+                self.read_offset += args.input_offset;
+
+                // Reset others
+                self.brotli_state = Box::new(BrotliState::new(
+                    StandardAlloc::default(),
+                    StandardAlloc::default(),
+                    StandardAlloc::default(),
+                ));
+
+                self.uncompressed_read = 0;
+
+                if args.output_offset == 0 {
+                    return self.read(buf);
+                }
+
+                Ok(args.output_offset)
+            }
+            brotli::BrotliResult::NeedsMoreInput => {
+                // Bytes may have been read and produced
+                self.read_offset += args.input_offset;
+                self.uncompressed_read += u32::try_from(args.output_offset).map_err(|_| {
+                    io::Error::new(io::ErrorKind::InvalidData, "Integer conversion failed")
+                })?;
+
+                if args.output_offset == 0 {
+                    // (NeedsMoreInput && output_offset == 0) means we can't produce output without more input
+                    //
+                    // if cache is full
+                    if self.read_offset == 0 && self.cache_filled_offset == self.cache.len() {
+                        self.cache.resize(self.cache.len() + 1, 0);
+                    } else {
+                        // move cache content at offset zero to make room for other input
+                        self.cache
+                            .copy_within(self.read_offset..self.cache_filled_offset, 0);
+                        self.cache_filled_offset -= self.read_offset;
+                        self.read_offset = 0;
+                        self.cache.resize(self.cache_filled_offset + 1, 0);
+                    }
+
+                    let read = self
+                        .inner
+                        .read(&mut self.cache[self.cache_filled_offset..])?;
+                    if read == 0 {
+                        // No more data from inner and the cache has been fully read
+                        // -> return either an error or Ok(0)
+                        if self.uncompressed_read > 0 {
+                            // Inside a stream and no more data available
+                            return Err(io::Error::new(
+                                io::ErrorKind::UnexpectedEof,
+                                "No more data from the inner layer",
+                            ));
+                        }
+                        // No more data available but not in a stream
+                        return Ok(0);
+                    }
+                    self.cache_filled_offset += read;
+                    return self.read(buf);
+                }
+                Ok(args.output_offset)
+            }
+            brotli::BrotliResult::NeedsMoreOutput => {
+                // Bytes may have been read and produced
+                self.read_offset += args.input_offset;
+                self.uncompressed_read += u32::try_from(args.output_offset).map_err(|_| {
+                    io::Error::new(io::ErrorKind::InvalidData, "Integer conversion failed")
+                })?;
+
+                Ok(args.output_offset)
+            }
+            brotli::BrotliResult::ResultFailure => Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "Invalid Data while decompressing",
+            )),
+        }
     }
 }
 
 impl<'a, R: 'a + Read> LayerFailSafeReader<'a, R> for CompressionLayerFailSafeReader<'a, R> {
     fn into_inner(self) -> Option<Box<dyn 'a + LayerFailSafeReader<'a, R>>> {
-        Some(self.state.into_inner())
+        Some(self.inner)
     }
 
     fn into_raw(self: Box<Self>) -> R {
-        self.state.into_inner().into_raw()
+        self.inner.into_raw()
     }
 }
 
-const FAIL_SAFE_BUFFER_SIZE: usize = 4096;
+const FAIL_SAFE_BUFFER_INITIAL_SIZE: usize = 1;
 
 impl<'a, R: 'a + Read> Read for CompressionLayerFailSafeReader<'a, R> {
-    /// This `read` is expected to end by failing
-    ///
+    /// This `read` may end by failing.
     /// Even in the best configuration, when the inner layer is not broken, the
-    /// decompression will fail while reading not-compressed data such as
+    /// decompression will fail if attempting to read not-compressed data such as
     /// `CompressionLayerReader` footer
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        // Use this mem::replace trick to be able to get back the compressor
-        // inner and freely move from CompressionLayerReaderState to others
-        let old_state =
-            std::mem::replace(&mut self.state, CompressionLayerFailSafeReaderState::Empty);
-        match old_state {
-            CompressionLayerFailSafeReaderState::Ready(inner) => {
-                self.state = CompressionLayerFailSafeReaderState::InData {
-                    cache: vec![0u8; FAIL_SAFE_BUFFER_SIZE],
-                    read_offset: 0,
-                    cache_filled_offset: 0,
-                    state: Box::new(BrotliState::new(
-                        StandardAlloc::default(),
-                        StandardAlloc::default(),
-                        StandardAlloc::default(),
-                    )),
-                    uncompressed_read: 0,
-                    inner,
-                };
-                self.read(buf)
-            }
-            CompressionLayerFailSafeReaderState::InData {
-                mut cache,
-                mut read_offset,
-                mut cache_filled_offset,
-                mut state,
-                mut uncompressed_read,
-                mut inner,
-            } => {
-                if uncompressed_read > UNCOMPRESSED_DATA_SIZE {
-                    return Err(Error::WrongReaderState(
-                        "[Compress FailSafe Layer] Too much data read".to_string(),
-                    )
-                    .into());
-                }
-
-                if read_offset == cache_filled_offset
-                    && cache_filled_offset == FAIL_SAFE_BUFFER_SIZE
-                {
-                    // Cache is full and there is no more data to read from
-                    // -> cache must be reset
-                    cache.fill(0);
-                    cache_filled_offset = 0;
-                    read_offset = 0;
-                }
-
-                // Try to fill the cache from the inner source
-                match inner.read(&mut cache[cache_filled_offset..]) {
-                    Ok(read) => {
-                        if read == 0 && read_offset == cache_filled_offset {
-                            // No more data from inner and the cache has been fully read
-                            // -> return either an error or Ok(0)
-                            if uncompressed_read > 0 {
-                                // Inside a stream and no more data available
-                                return Err(io::Error::new(
-                                    io::ErrorKind::UnexpectedEof,
-                                    "No more data from the inner layer",
-                                ));
-                            }
-                            // No more data available but not in a stream
-                            return Ok(0);
-                        }
-                        cache_filled_offset += read;
-                    }
-                    error => {
-                        if read_offset == cache_filled_offset {
-                            // No more data in the cache
-                            return error;
-                        }
-                        // There is still data in the cache to read
-                        // Will fail and return the error on the next .read()
-                    }
-                }
-
-                // Number of byte available in the source
-                let mut available_in = cache_filled_offset - read_offset;
-                // IN: Offset in the source
-                // OUT: Offset in the source after the decompression pass
-                let mut input_offset = 0;
-                // Available spaces in the output
-                let mut available_out = std::cmp::min(
-                    buf.len(),
-                    (UNCOMPRESSED_DATA_SIZE - uncompressed_read) as usize,
-                );
-                // IN: Offset in the output
-                // OUT: number of bytes written in the output
-                let mut output_offset = 0;
-                // OUT: total number of byte written for the current stream (cumulative)
-                let mut written = 0;
-
-                let ret = match brotli::BrotliDecompressStream(
-                    &mut available_in,
-                    &mut input_offset,
-                    &cache[read_offset..cache_filled_offset],
-                    &mut available_out,
-                    &mut output_offset,
-                    buf,
-                    &mut written,
-                    &mut state,
-                ) {
-                    brotli::BrotliResult::ResultSuccess => {
-                        // End of stream reached
-
-                        // Rewind the cache to the actual start of the new block
-                        // input_offset \in [0; cache_filled_offset - read_offset[
-                        read_offset += input_offset;
-
-                        // Reset others
-                        state = Box::new(BrotliState::new(
-                            StandardAlloc::default(),
-                            StandardAlloc::default(),
-                            StandardAlloc::default(),
-                        ));
-                        uncompressed_read = 0;
-
-                        Ok(output_offset)
-                    }
-                    brotli::BrotliResult::NeedsMoreInput => {
-                        // Bytes may have been read and produced
-                        read_offset += input_offset;
-                        uncompressed_read += u32::try_from(output_offset).map_err(|_| {
-                            io::Error::new(io::ErrorKind::InvalidData, "Integer conversion failed")
-                        })?;
-
-                        Ok(output_offset)
-                    }
-                    brotli::BrotliResult::NeedsMoreOutput => {
-                        // Bytes may have been read and produced
-                        read_offset += input_offset;
-                        uncompressed_read += u32::try_from(output_offset).map_err(|_| {
-                            io::Error::new(io::ErrorKind::InvalidData, "Integer conversion failed")
-                        })?;
-
-                        Ok(output_offset)
-                    }
-                    brotli::BrotliResult::ResultFailure => Err(io::Error::new(
-                        io::ErrorKind::InvalidData,
-                        "Invalid Data while decompressing",
-                    )),
-                };
-
-                self.state = CompressionLayerFailSafeReaderState::InData {
-                    cache,
-                    cache_filled_offset,
-                    read_offset,
-                    state,
-                    uncompressed_read,
-                    inner,
-                };
-
-                ret
-            }
-            CompressionLayerFailSafeReaderState::Empty => Err(Error::WrongReaderState(
-                "[Compression Layer] Should never happens, unless an error already occurs before"
-                    .to_string(),
+        if self.uncompressed_read > UNCOMPRESSED_DATA_SIZE {
+            return Err(Error::WrongReaderState(
+                "[Compress FailSafe Layer] Too much data read".to_string(),
             )
-            .into()),
+            .into());
         }
+
+        if buf.is_empty() {
+            return Ok(0);
+        }
+
+        // Number of byte available in the source
+        let available_in = self.cache_filled_offset - self.read_offset;
+        // IN: Offset in the source
+        // OUT: Offset in the source after the decompression pass
+        let input_offset = 0;
+        // Available spaces in the output
+        let available_out = std::cmp::min(
+            buf.len(),
+            (UNCOMPRESSED_DATA_SIZE - self.uncompressed_read) as usize,
+        );
+        // IN: Offset in the output
+        // OUT: number of bytes written in the output
+        let output_offset = 0;
+        // OUT: total number of byte written for the current stream (cumulative)
+        let written = 0;
+
+        let params = FailSafeDecompressStreamParams {
+            available_in,
+            input_offset,
+            available_out,
+            output_offset,
+            written,
+        };
+        self.fail_safe_decompress_stream(params, buf)
     }
+}
+
+struct FailSafeDecompressStreamParams {
+    available_in: usize,
+    input_offset: usize,
+    available_out: usize,
+    output_offset: usize,
+    written: usize,
 }
 
 #[cfg(test)]
@@ -1204,12 +1167,9 @@ mod tests {
             comp.write_all(bytes).unwrap();
             comp.finalize().unwrap();
             let file = comp.into_raw();
-            let mut decomp = Box::new(
-                CompressionLayerFailSafeReader::new(Box::new(RawLayerFailSafeReader::new(
-                    file.as_slice(),
-                )))
-                .unwrap(),
-            );
+            let mut decomp = Box::new(CompressionLayerFailSafeReader::new(Box::new(
+                RawLayerFailSafeReader::new(file.as_slice()),
+            )));
             let mut buf = Vec::new();
             // This must ends with an error, when we start reading the footer (invalid for decompression)
             decomp.read_to_end(&mut buf).unwrap_err();
@@ -1244,12 +1204,9 @@ mod tests {
             // Truncate at the middle
             let stop = file.len() / 2;
 
-            let mut decomp = Box::new(
-                CompressionLayerFailSafeReader::new(Box::new(RawLayerFailSafeReader::new(
-                    &file[..stop],
-                )))
-                .unwrap(),
-            );
+            let mut decomp = Box::new(CompressionLayerFailSafeReader::new(Box::new(
+                RawLayerFailSafeReader::new(&file[..stop]),
+            )));
             let mut buf = Vec::new();
             // This is expected to ends with an error
             decomp.read_to_end(&mut buf).unwrap_err();

--- a/mla/src/lib.rs
+++ b/mla/src/lib.rs
@@ -1340,7 +1340,7 @@ impl<'b, R: 'b + Read> ArchiveFailSafeReader<'b, R> {
             src = Box::new(EncryptionLayerFailSafeReader::new(src, &config.encrypt)?);
         }
         if config.layers_enabled.contains(Layers::COMPRESS) {
-            src = Box::new(CompressionLayerFailSafeReader::new(src)?);
+            src = Box::new(CompressionLayerFailSafeReader::new(src));
         }
 
         Ok(Self { config, src })


### PR DESCRIPTION
# Fix regarding incomplete repaired archive

## Overview

CompressionFailSafeReader was returning Ok(0) too early when BrotliDecompressStream was returning a NeedsMoreInput with an output_offset of 0.

We fix this by checking this case, getting more input if needed and retrying decompression.

All sorts of other corner cases have been handled in this new implementation, including ones potentially not handled by previous implementation with BrotliDecompressor.

e.g. it did not handle the case where when BrotliDecompressor calls BrotliDecompressStream and it returns NeedsMoreInput twice, it could return an error if no input was consumed.

We had to return to a potentially slower implementation where we generally call BrotliDecompressStream by feeding it byte by byte. Otherwise it may not return all its output on failure.

This commits also removes unneeded enum states in CompressionFailSafeReader and moves handling of BrotliDecompressStream in a dedicated brotli_decompress_stream function.

## Related issues

Link to any related issues or tasks:
- Fixes #226 

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] My code follows the project's style guidelines
- [x] Performed a self-review of the code.
- [x] Added comments for complex code sections.
- [x] Verified that all tests pass locally.
- [x] Updated relevant documentation.