### PR TITLE
Deny more things for windows entry names interpreted as paths and relax a bit escaping

### DIFF
--- a/doc/src/ENTRY_NAME.md
+++ b/doc/src/ENTRY_NAME.md
@@ -45,13 +45,13 @@ To prevent some security risks, proposed string representations of entry names
 are given with `EntryName::to_pathbuf_escaped_string` and
 `EntryName::raw_content_to_escaped_string` and are used by `mlar`.
 
-Other representations may be preferred depending on its usage context.
+Other representations may be preferred depending on their usage context.
 
 The idea of this representation is that unwanted bytes are replaced with a
 percent and their hexadecimal representation. Details follow.
 
 For an entry name interpreted as raw bytes, below generic escaping is applied
-with ASCII alphanumeric chars and ASCII dot as preserved bytes. This is used by
+with ASCII alphanumeric, dot, dash and underscore as preserved bytes. This is used by
 `mlar list --raw-escaped-names`.
 
 For an entry name interpreted as a path, below generic escaping is applied

--- a/mla/src/entry.rs
+++ b/mla/src/entry.rs
@@ -17,11 +17,11 @@ mod entryname {
     use crate::{FILENAME_MAX_SIZE, helpers::mla_percent_escape};
 
     /// Allowed bytes in `EntryName::to_pathbuf_escaped_string` output. Documented there.
-    pub static ENTRY_NAME_PATHBUF_ESCAPED_STRING_ALLOWED_BYTES: [u8; 64] =
-        *b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789./";
+    pub static ENTRY_NAME_PATHBUF_ESCAPED_STRING_ALLOWED_BYTES: [u8; 66] =
+        *b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789.-_/";
     /// Allowed bytes in `EntryName::raw_content_to_escaped_string` output. Documented there.
-    pub static ENTRY_NAME_RAW_CONTENT_ALLOWED_BYTES: [u8; 63] =
-        *b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789.";
+    pub static ENTRY_NAME_RAW_CONTENT_ALLOWED_BYTES: [u8; 65] =
+        *b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789.-_";
 
     // https://github.com/MicrosoftDocs/win32/blob/63e70903d18b0637e62ffab6656c4a388ef0f2ce/desktop-src/FileIO/naming-a-file.md
     #[cfg(target_family = "windows")]


### PR DESCRIPTION
# Deny more things for windows entry names interpreted as paths and relax a bit escaping

## Overview

Deny more things for windows entry names interpreted as paths and relax a bit escaping as dash and underscore are often used and seem innocuous.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [x] Other (please specify): Enhancement

## Checklist

- [x] My code follows the project's style guidelines
- [x] Performed a self-review of the code.
- [x] Added comments for complex code sections.
- [ ] Added or updated tests to verify changes.
- [x] Verified that all tests pass locally.
- [x] Updated relevant documentation.