### PR TITLE
Remove obsolete images and build due to obsolescense

### DIFF
--- a/.github/workflows/py-bindings.yml
+++ b/.github/workflows/py-bindings.yml
@@ -85,8 +85,6 @@ jobs:
         platform:
           - runner: windows-latest
             target: x64
-          - runner: windows-latest
-            target: x86
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0

--- a/.github/workflows/py-bindings.yml
+++ b/.github/workflows/py-bindings.yml
@@ -138,9 +138,7 @@ jobs:
     strategy:
       matrix:
         platform:
-          # as latest macos versions now default to aarch64, x86_64 is not available
-          - runner: macos-13
-            target: x86_64
+          # no x86_64 targets as latest macos versions now default to aarch64, x86_64 is not available
           - runner: macos-latest
             target: aarch64
     steps:


### PR DESCRIPTION
# PR summary

**What does this PR do?**
Fix : 
- https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/ : no more x86_64 builds for macos (starting from macos-14) -- hence we remove associated workflows in CI
- https://github.com/actions/setup-python/issues/672 : actions/setup-python depreciate windows x86 builds -- hence we remove associated workflows in CI
  - Supporting 32-bit Windows (Win32) Python bindings is not critical, as the `mla-bindings-py` component is still in early development and we don’t anticipate legacy usage requiring 32-bit support.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Breaking change
- [ ] Documentation

<!-- If applicable
## Screenshots / Context

_Add before/after screenshots, logs, or extra notes if helpful_
-->

<!--
Checklist:

- Read the [Contributing Guidelines](https://github.com/ANSSI-FR/MLA/blob/main/.github/CONTRIBUTING.md)
- Add tests for all changed behaviour.
- If you can't add a test, please explain why and how you verified your changes work.
- Make sure CI passes.
- Please do not force push to the PR once it has been reviewed.

-->
