### PR TITLE
Implement archive decryption with shared secret

### DIFF
--- a/mla/src/crypto/hybrid.rs
+++ b/mla/src/crypto/hybrid.rs
@@ -33,13 +33,25 @@ type EncryptedSharedSecret = HybridKemSharedSecretArray;
 /// A shared secret, as produced by the Hybrid KEM decapsulation/encapsulation
 ///
 /// The type is wrapped to ease future changes & traits implementation
-#[derive(Zeroize, ZeroizeOnDrop, Debug)]
+#[derive(Clone, Debug, Zeroize, ZeroizeOnDrop)]
 pub(crate) struct HybridKemSharedSecret(pub(crate) HybridKemSharedSecretArray);
 
 impl HybridKemSharedSecret {
     /// Generate a new `HybridKemSharedSecret` from a CSPRNG
     pub fn from_rng<R: CryptoRngCore>(csprng: &mut R) -> Self {
         Self(csprng.r#gen::<HybridKemSharedSecretArray>())
+    }
+}
+
+impl<R: Read> MLADeserialize<R> for HybridKemSharedSecret {
+    fn deserialize(src: &mut R) -> Result<Self, Error> {
+        Ok(HybridKemSharedSecret(MLADeserialize::deserialize(src)?))
+    }
+}
+
+impl<W: Write> MLASerialize<W> for HybridKemSharedSecret {
+    fn serialize(&self, dest: &mut W) -> Result<u64, Error> {
+        self.0.as_slice().serialize(dest)
     }
 }
 


### PR DESCRIPTION
# PR summary

**What does this PR do?**
This commit enhances the MLA library by adding support for decrypting archives using shared secrets, which can be particularly useful in distributed systems where you want to keep private keys secure on a separate machine. The implementation includes new structures, serialization/deserialization methods, configuration updates, CLI commands, and tests to ensure the functionality works as expected.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Breaking change
- [ ] Documentation

**To be merged after #425**

<!-- If applicable
## Screenshots / Context

_Add before/after screenshots, logs, or extra notes if helpful_
-->

<!--
Checklist:

- Read the [Contributing Guidelines](https://github.com/ANSSI-FR/MLA/blob/main/.github/CONTRIBUTING.md)
- Add tests for all changed behaviour.
- If you can't add a test, please explain why and how you verified your changes work.
- Make sure CI passes.
- Please do not force push to the PR once it has been reviewed.

-->
