### PR TITLE
Mark some pub items as non exhaustive

### DIFF
--- a/bindings/C/src/lib.rs
+++ b/bindings/C/src/lib.rs
@@ -232,7 +232,7 @@ impl From<MLAError> for MLAStatus {
             }
             MLAError::TruncatedTag => MLAStatus::TruncatedTag,
             MLAError::UnknownTagPosition => MLAStatus::UnknownTagPosition,
-            MLAError::Other(_) => MLAStatus::Other,
+            _ => MLAStatus::Other,
         }
     }
 }

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -339,6 +339,7 @@ impl From<WrappedError> for PyErr {
                     PyErr::new::<UnknownTagPosition, _>("UnknownTagPosition")
                 }
                 mla::errors::Error::Other(err) => PyErr::new::<MLAOther, _>(err.clone()),
+                _ => PyErr::new::<MLAOther, _>(String::from("unexpected mla error")),
             },
             WrappedError::WrappedPy(inner_err) => inner_err,
             WrappedError::EntryNameError => PyErr::new::<EntryNameError, _>(

--- a/mla/src/config.rs
+++ b/mla/src/config.rs
@@ -244,6 +244,7 @@ impl IncompleteArchiveReaderConfig {
 }
 
 /// `TruncatedReader` decryption mode
+#[non_exhaustive]
 #[derive(Default, Clone, Copy, Eq, PartialEq, Debug)]
 pub enum TruncatedReaderDecryptionMode {
     /// Returns only the data that have been authenticated (in AEAD meaning, there will be NO signature verification) on decryption

--- a/mla/src/entry.rs
+++ b/mla/src/entry.rs
@@ -77,6 +77,7 @@ mod entryname {
         b"conout$",
     ];
 
+    #[non_exhaustive]
     #[derive(Debug)]
     pub enum EntryNameError {
         ForbiddenPathTraversalComponent,
@@ -484,6 +485,7 @@ pub(crate) fn deserialize_entry_name(mut src: impl Read) -> Result<EntryName, Er
 }
 
 /// Represents an entry in the archive.
+#[non_exhaustive]
 pub struct ArchiveEntry<'a, T> {
     pub name: EntryName,
     pub data: ArchiveEntryDataReader<'a, T>,

--- a/mla/src/errors.rs
+++ b/mla/src/errors.rs
@@ -5,6 +5,7 @@ use std::error;
 use std::fmt;
 use std::io;
 
+#[non_exhaustive]
 #[derive(Debug)]
 pub enum Error {
     /// IO Error (not enough data, etc.)
@@ -125,6 +126,7 @@ impl error::Error for Error {
     }
 }
 
+#[non_exhaustive]
 #[derive(Debug)]
 pub enum TruncatedReadError {
     /// Everything ends correctly
@@ -182,6 +184,7 @@ impl error::Error for TruncatedReadError {
     }
 }
 
+#[non_exhaustive]
 #[derive(Debug)]
 pub enum ConfigError {
     IncoherentPersistentConfig,


### PR DESCRIPTION
# PR summary

**What does this PR do?**
Mark some pub items (struct, enum) with non exhaustive attribute. This will enable future additions without breaking existing user codes.

<!-- If  this PR fixes an issue
**Related issues:**
Fixes #[issue-number]
-->

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Breaking change
- [ ] Documentation

<!-- If applicable
## Screenshots / Context

_Add before/after screenshots, logs, or extra notes if helpful_
-->

<!--
Checklist:

- Read the [Contributing Guidelines](https://github.com/ANSSI-FR/MLA/blob/main/.github/CONTRIBUTING.md)
- Add tests for all changed behaviour.
- If you can't add a test, please explain why and how you verified your changes work.
- Make sure CI passes.
- Please do not force push to the PR once it has been reviewed.

-->
