### PR TITLE
Support alternative key format line separator besides CRLF

### DIFF
--- a/doc/src/KEY_FORMAT.md
+++ b/doc/src/KEY_FORMAT.md
@@ -4,9 +4,13 @@ MLA can use cryptography for signature and/or encryption. Thus it needs to opera
 
 The string `||` denotes concatenation.
 
+## Separator
+
+A separator named `Sep` is used in MLA key serialization formats described below. It is usually a `<CR><LF>` where `<CR>` is ASCII carriage return, `<LF>` is ASCII line feed. If one wants a key without newlines, `Sep` with value `__` (two ASCII underscores) is also valid.
+
 ## Private key file format
 
-A private key file is an ASCII file, which may use `mlapriv` as file extension. The file (or whatever serialization medium) content is `PrivFormatHeader||<CR><LF>PrivEncHdr||B64Priv4Enc||<CR><LF>||PrivSigHdr||B64Priv4Sig||<CR><LF>||B64PrivOpts||<CR><LF>||PrivFormatFooter||<CR><LF>` where `<CR>` is ASCII carriage return, `<LF>` is ASCII line feed, and `PrivFormatHeader`, `PrivEncHdr`, `B64Priv4Enc`, `PrivSigHdr`, `B64Priv4Sig`, `B64PrivOpts` and `PrivFormatFooter` are described below.
+A private key file is an ASCII file, which may use `mlapriv` as file extension. The file (or whatever serialization medium) content is `PrivFormatHeader||Sep||PrivEncHdr||B64Priv4Enc||Sep||PrivSigHdr||B64Priv4Sig||Sep||B64PrivOpts||Sep||PrivFormatFooter||Sep`, where `PrivFormatHeader`, `PrivEncHdr`, `B64Priv4Enc`, `PrivSigHdr`, `B64Priv4Sig`, `B64PrivOpts` and `PrivFormatFooter` are described below.
 
 * `PrivFormatHeader` is the ASCII string `DO NOT SEND THIS TO ANYONE - MLA PRIVATE KEY FILE V1`.
 * `PrivEncHdr` is the ASCII string `MLA PRIVATE DECRYPTION KEY ` (note the trailing space).
@@ -28,7 +32,7 @@ For `PrivEncOpts` and `PrivSigOpts`, refer to below generic explanation for `Key
 
 ## Public key file format
 
-A public key file is an ASCII file, which may use `mlapub` as file extension. The file (or whatever serialization medium) content is `PubFormatHeader||<CR><LF>||PubEncHdr||B64Pub4Enc||<CR><LF>||PubSigHdr||B64Pub4Sig||<CR><LF>||B64PubOpts||<CR><LF>||PubFormatFooter||<CR><LF>` where `<CR>` is ASCII carriage return, `<LF>` is ASCII line feed, and `PubFormatHeader`, `PubEncHdr`, `B64Pub4Enc`, `PubSigHdr`, `B64Pub4Sig`, `B64PubOpts` and `PubFormatFooter` are described below.
+A public key file is an ASCII file, which may use `mlapub` as file extension. The file (or whatever serialization medium) content is `PubFormatHeader||Sep||PubEncHdr||B64Pub4Enc||Sep||PubSigHdr||B64Pub4Sig||Sep||B64PubOpts||Sep||PubFormatFooter||Sep` where `PubFormatHeader`, `PubEncHdr`, `B64Pub4Enc`, `PubSigHdr`, `B64Pub4Sig`, `B64PubOpts` and `PubFormatFooter` are described below.
 
 * `PubFormatHeader` is the ASCII string `MLA PUBLIC KEY FILE V1`.
 * `PubEncHdr` is the ASCII string `MLA PUBLIC ENCRYPTION KEY " (note the trailing space).


### PR DESCRIPTION
# PR summary

**What does this PR do?**
Support alternative key format line separator besides CRLF

<!-- If this PR fixes an issue
**Related issues:**
Fixes #[issue-number]
-->

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Breaking change
- [ ] Documentation

<!-- If applicable
## Screenshots / Context

_Add before/after screenshots, logs, or extra notes if helpful_
-->

<!--
Checklist:

- Read the [Contributing Guidelines](https://github.com/ANSSI-FR/MLA/blob/main/.github/CONTRIBUTING.md)
- Add tests for all changed behaviour.
- If you can't add a test, please explain why and how you verified your changes work.
- Make sure CI passes.
- Please do not force push to the PR once it has been reviewed.

-->
