### PR TITLE
Temporarily increase stack size to 8 MiB for windows-msvc builds

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,3 +1,12 @@
-# static linking on Windows, avoids the need for a Visual Studio installation
 [target.'cfg(all(windows, target_env = "msvc"))']
-rustflags = ["-C", "target-feature=+crt-static"]
+rustflags = [
+    # Static linking on Windows (avoids requiring Visual Studio)
+    "-C", "target-feature=+crt-static",
+    # Temporarily increase stack size to 8 MiB to prevent stack overflows during ML-DSA key deserialization.
+    # Related:
+    # - Issue: https://github.com/RustCrypto/signatures/issues/1024 (Windows stack overflow with ML-DSA)
+    # - Fixed upstream by: https://github.com/RustCrypto/signatures/pull/1261 (reduces stack usage by 207kb for ML-DSA-87)
+    # TODO: remove once MLA adopts the 0.1.0 stable ml-dsa version (with stack fixes)
+    # Additional context: https://github.com/RustCrypto/KEMs/pull/310 (heap offloading added for ml-kem `alloc` feature, enabled by default)
+    "-C", "link-arg=/STACK:8388608",
+]


### PR DESCRIPTION
# PR summary

**What does this PR do?**
Temporarily increase stack size to 8 MiB for windows-msvc builds. This prevents stack overflows during ML-DSA key deserialization for instance.

<!-- If this PR fixes an issue
**Related issues:**
Fixes #[issue-number]
-->

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Breaking change
- [ ] Documentation

<!-- If applicable
## Screenshots / Context

_Add before/after screenshots, logs, or extra notes if helpful_
-->

<!--
Checklist:

- Read the [Contributing Guidelines](https://github.com/ANSSI-FR/MLA/blob/main/.github/CONTRIBUTING.md)
- Add tests for all changed behaviour.
- If you can't add a test, please explain why and how you verified your changes work.
- Make sure CI passes.
- Please do not force push to the PR once it has been reviewed.

-->
