### PR TITLE
Convert ArchiveReader::get_entry return type to a named one to avoid opaque type

### DIFF
--- a/mla/src/lib.rs
+++ b/mla/src/lib.rs
@@ -1020,6 +1020,10 @@ fn read_mla_entries_header_skip_magic(mut src: impl Read) -> Result<(), Error> {
     Ok(())
 }
 
+/// Returned by `ArchiveReader::get_entry`. It is the readable type underneath `ArchiveEntryDataReader`.
+/// `LayerReader` is an internal private trait
+pub type BoxedLayerReader<'b, R> = Box<dyn 'b + LayerReader<'b, R>>;
+
 impl<'b, R: 'b + InnerReaderTrait> ArchiveReader<'b, R> {
     /// Create an `ArchiveReader`.
     pub fn from_config(
@@ -1183,10 +1187,10 @@ impl<'b, R: 'b + InnerReaderTrait> ArchiveReader<'b, R> {
     /// If no entry is found with given `name`, returns `Ok(None)`.
     /// If found, return `Ok(Some(e))` where e is an `ArchiveEntry`, letting you read its content and size.
     /// Returns an `Err` on error...
-    pub fn get_entry(
-        &mut self,
+    pub fn get_entry<'a>(
+        &'a mut self,
         name: EntryName,
-    ) -> Result<Option<ArchiveEntry<'_, impl InnerReaderTrait>>, Error> {
+    ) -> Result<Option<ArchiveEntry<'a, BoxedLayerReader<'b, R>>>, Error> {
         if let Some(ArchiveFooter { entries_info }) = &self.metadata {
             // Get file relative information
             let Some(file_info) = entries_info.get(&name) else {
@@ -1199,8 +1203,8 @@ impl<'b, R: 'b + InnerReaderTrait> ArchiveReader<'b, R> {
             }
 
             // Instantiate the file representation
-            let reader = ArchiveEntryDataReader::new(&mut self.src, &file_info.offsets_and_sizes)?;
-            Ok(Some(ArchiveEntry { name, data: reader }))
+            let data = ArchiveEntryDataReader::new(&mut self.src, &file_info.offsets_and_sizes)?;
+            Ok(Some(ArchiveEntry { name, data }))
         } else {
             Err(Error::MissingMetadata)
         }

--- a/mlar/src/main.rs
+++ b/mlar/src/main.rs
@@ -1378,7 +1378,7 @@ fn to_tar(matches: &ArgMatches) -> Result<(), MlarError> {
                 let escaped = entry_name
                     .to_pathbuf_escaped_string()
                     .map_err(|_| MlarError::EntryNameEscapeFailed)?;
-                eprintln!("[ERROR] Failed to find entry \"{escaped}\" indexed in metadata",);
+                eprintln!("[ERROR] Failed to find entry \"{escaped}\" indexed in metadata");
                 return Err(MlarError::EntryNotFound);
             }
             Ok(Some(entry)) => entry,
@@ -1387,7 +1387,7 @@ fn to_tar(matches: &ArgMatches) -> Result<(), MlarError> {
             let escaped = entry_name
                 .to_pathbuf_escaped_string()
                 .map_err(|_| MlarError::EntryNameEscapeFailed)?;
-            eprintln!("[ERROR] Unable to add entry \"{escaped}\" to tarball ({err:?})",);
+            eprintln!("[ERROR] Unable to add entry \"{escaped}\" to tarball ({err:?})");
             return Err(err);
         }
     }


### PR DESCRIPTION
Having an opaque (impl trait) return type meant difficulty for users to store returned value in an other type.

# PR summary

**What does this PR do?**
Convert ArchiveReader::get_entry return type to a named one to avoid opaque type.

<!-- If this PR fixes an issue
**Related issues:**
Fixes #[issue-number]
-->

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Breaking change
- [ ] Documentation

<!-- If applicable
## Screenshots / Context

_Add before/after screenshots, logs, or extra notes if helpful_
-->

<!--
Checklist:

- Read the [Contributing Guidelines](https://github.com/ANSSI-FR/MLA/blob/main/.github/CONTRIBUTING.md)
- Add tests for all changed behaviour.
- If you can't add a test, please explain why and how you verified your changes work.
- Make sure CI passes.
- Please do not force push to the PR once it has been reviewed.

-->
