### PR TITLE
Revert doc crypto change

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ https://crates.io/crates/mlar)
 
 MLA is an archive file format with the following features:
 
-* Support for classic and post-quantum encryption hybridization with asymmetric keys (HPKE with AES256-GCM and a KEM based on an hybridization of X25519 and post-quantum ML-KEM 1024)
-* Support for classic and post-quantum signing hybridization
+* Support for traditional and post-quantum encryption hybridization with asymmetric keys (HPKE with AES256-GCM and a KEM based on an hybridization of X25519 and post-quantum ML-KEM 1024)
+* Support for traditional and post-quantum signing hybridization
 * Support for compression (based on [`rust-brotli`](https://github.com/dropbox/rust-brotli/))
 * Streamable archive creation:
   * An archive can be built even over a data-diode

--- a/doc/src/CRYPTO.md
+++ b/doc/src/CRYPTO.md
@@ -10,7 +10,7 @@ Keys used for encryption and signature are generated and used separately.
 
 As described in `FORMAT.md` an archive can be signed. Implementation must ensure users explicitly choose if signature is made and verified.
 
-A PQ/C key consists of a pair of a post-quantum key and a classic key. An archive is considered correctly signed for a PQ/C key if and only if it is correctly signed for its post-quantum part AND its classic part.
+A PQ/T key consists of a pair of a post-quantum key and a traditional key. An archive is considered correctly signed for a PQ/T key if and only if it is correctly signed for its post-quantum part AND its traditional part.
 
 Two signature methods are available and must be used together. Signature method input is called `m`. The SHA-512 hash `h` of `m` may be computed in a first step.
 
@@ -18,7 +18,7 @@ For method `MLAEd25519SigMethod`, `signature_data` is the Ed25519 signature (as 
 
 For method `MLAMLDSA87SigMethod`, `signature_data` is the ML-DSA-87 signature (as described in FIPS 204 [^fips204], not HashML-DSA) of `h` with the ASCII `MLAMLDSA87SigMethod` as context. Signature verification and key generation are done as described in FIPS 204. Key storage is described in `KEY_FORMAT.md`.
 
-An archive can be signed with multiple signing keys. If a user provides a set of PQ/C keys for signature verification, implementations should give a way for the user to know if archive is correctly signed for at least one key. Implementations may give a way for users to know if archive is correctly signed for all keys. Users must explicitly know if they are validating against at least one or all keys. Implementations may also give a way for users to know which PQ/C keys correspond to valid signatures or their number.
+An archive can be signed with multiple signing keys. If a user provides a set of PQ/T keys for signature verification, implementations should give a way for the user to know if archive is correctly signed for at least one key. Implementations may give a way for users to know if archive is correctly signed for all keys. Users must explicitly know if they are validating against at least one or all keys. Implementations may also give a way for users to know which PQ/T keys correspond to valid signatures or their number.
 
 ### Encryption high-level overview
 
@@ -344,7 +344,7 @@ final\_chunk& = \textrm{Encrypt}_{AES\ 256\ GCM}(\\
 The resulting layer is composed of:
 
 - header: $ct_{recipients}$
-- data: $keycommit \ .\ enc_0 \dots enc_n \ .$ $final\_chunk$
+- data: $keycommit \ .\ enc_0\ . \dots\ enc_n \ .$ $final\_chunk$
 
 Special care must be taken not to reuse a sequence number in implementations as this would be catastrophic given GCM properties. For $n$ chunks of data:
 * sequence 0: key commitment
@@ -469,10 +469,10 @@ MLA relies on several external cryptographic libraries for its primitives. Below
     - **Documentation:** Well documented and widely used in the Rust ecosystem.
     - **Note:** GCM mode is re-implemented in MLA for chunked/partial decryption.
 
-#### Classical Signature
+#### Traditional Signature
 
 - **ed25519-dalek**
-    - **Role:** Ed25519 signatures (RFC 8032) for the classic part of hybrid signatures.
+    - **Role:** Ed25519 signatures (RFC 8032) for the traditional part of hybrid signatures.
     - **Review** [^reviewqb].
     - **Documentation:** Well documented, widely used, and considered production-grade.
 
@@ -487,7 +487,7 @@ MLA relies on several external cryptographic libraries for its primitives. Below
 #### Hybrid Signature Logic
 
 - **Custom implementation in MLA (`hybrid_signature.rs`, `mlakey.rs`)**
-    - **Role:** Combines Ed25519 and ML-DSA-87 for hybrid PQ/C signatures.
+    - **Role:** Combines Ed25519 and ML-DSA-87 for hybrid PQ/T signatures.
     - **Review:** No third-party audit. Covered by internal tests and verified against official test vectors.
 
 #### Asymmetric Encryption (Hybrid KEM)
@@ -534,7 +534,7 @@ MLA relies on several external cryptographic libraries for its primitives. Below
 
 - Elliptic curve cryptography (Curve25519/X25519) is used over RSA due to the lack of ready-for-production Rust-based RSA libraries, the availability of audited Curve25519 libraries, and its widespread use and security properties ([SafeCurves](https://safecurves.cr.yp.to/), [Trail of Bits arguments](https://blog.trailofbits.com/2019/07/08/fuck-rsa/)).
 - AES-GCM is chosen for authenticated encryption due to its common use, hardware acceleration support (e.g., AES-NI), and avoidance of a class of attacks.
-- MLA’s hybrid approach (combining classic and post-quantum primitives) limits the impact of potential flaws in less mature or unaudited libraries (e.g., MLKEM, ML-DSA).
+- MLA’s hybrid approach (combining traditional and post-quantum primitives) limits the impact of potential flaws in less mature or unaudited libraries (e.g., MLKEM, ML-DSA).
 - MLA includes regression tests and test vectors for all critical cryptographic operations.
 - Custom cryptographic logic (e.g., hybrid KEM, hybrid signature, chunked AES-GCM) is described in this document and tested against standards.
 

--- a/doc/src/FORMAT.md
+++ b/doc/src/FORMAT.md
@@ -38,7 +38,7 @@ Notes: '?' indicates optional layers. Layer order is security-sensitive: signatu
 - Entries stream: The core logical stream of files (entries) is a sequence of blocks (EntryStart, EntryContentChunk, EndOfEntry, EndOfArchiveData). This is where file names, interleaved content chunks, and per-entry hashes live.
 - Compression layer (optional): Splits the inner bytes into fixed-size chunks (4 MiB), compresses each chunk (Brotli), and records compressed sizes in a footer (SizesInfo) so random access to compressed chunks is feasible.
 - Encryption layer (optional): Performs chunked AES-GCM encryption of inner bytes with per-recipient encapsulated keys which encrypts a shared secret; chunks carry explicit sequence numbers and tags. The final encrypted block must decrypt to a `FINALBLOCK` marker for truncation protection.
-- Signature layer (optional): Covers all bytes from the MLA header up through the inner layer; it supports two signatures kinds: classic and post-quantum. Signature blobs are generated for the covered data. Readers must verify at least one valid signature of each kind (when signature verification is requested).
+- Signature layer (optional): Covers all bytes from the MLA header up through the inner layer; it supports two signatures kinds: traditional and post-quantum. Signature blobs are generated for the covered data. Readers must verify at least one valid signature of each kind (when signature verification is requested).
 
 ### Relationship to the formal specification below
 

--- a/mla/CHANGELOG.md
+++ b/mla/CHANGELOG.md
@@ -10,8 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added/Changed since 1.3.0
 
 - MLA2 is now the default; it is **incompatible** with MLA1. MLA1 enters **low maintenance mode**
-- Hybrid classic/post-quantum encryption using **X25519 + ML-KEM1024**
-- Archive signing using hybrid classic/post-quantum signatures
+- Hybrid traditional/post-quantum encryption using **X25519 + ML-KEM1024**
+- Archive signing using hybrid traditional/post-quantum signatures
 - Switched to **Rust 2024 edition**
 - Key commitment support for AES-GCM
 - New archive format, enabling improved cryptographic and performance characteristics
@@ -80,8 +80,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added/Changed
 
 - MLA2 is now the default; it is **incompatible** with MLA1. MLA1 enters **low maintenance mode**
-- Hybrid classic/post-quantum encryption using **X25519 + ML-KEM1024**
-- Archive signing using hybrid classic/post-quantum signatures
+- Hybrid traditional/post-quantum encryption using **X25519 + ML-KEM1024**
+- Archive signing using hybrid traditional/post-quantum signatures
 - Switched to **Rust 2024 edition**
 - Key commitment support for AES-GCM
 - New archive format, enabling improved cryptographic and performance characteristics

--- a/mla/src/layers/signature.rs
+++ b/mla/src/layers/signature.rs
@@ -228,13 +228,13 @@ impl<'a, R: 'a + InnerReaderTrait> SignatureLayerReader<'a, R> {
                     .iter()
                     .filter(|sig| key.verify(signed_hash.clone(), sig))
                     .collect::<Vec<_>>();
-                let classic_signature_verified = verified_signatures
+                let traditional_signature_verified = verified_signatures
                     .iter()
                     .any(|sig| matches!(sig, MLASignature::MLAEd25519(_)));
                 let post_quantum_signature_verified = verified_signatures
                     .iter()
                     .any(|sig| matches!(sig, MLASignature::MLAMlDsa87(_)));
-                if classic_signature_verified && post_quantum_signature_verified {
+                if traditional_signature_verified && post_quantum_signature_verified {
                     keys_ref_with_valid_signatures.push(key);
                 }
             }

--- a/mla/src/lib.rs
+++ b/mla/src/lib.rs
@@ -2,8 +2,8 @@
 //!
 //! MLA is an archive file format with the following features:
 //!
-//! * Support for classic and post-quantum encryption hybridization with asymmetric keys (HPKE with AES256-GCM and a KEM based on an hybridization of X25519 and post-quantum ML-KEM 1024)
-//! * Support for classic and post-quantum signature hybridization
+//! * Support for traditional and post-quantum encryption hybridization with asymmetric keys (HPKE with AES256-GCM and a KEM based on an hybridization of X25519 and post-quantum ML-KEM 1024)
+//! * Support for traditional and post-quantum signature hybridization
 //! * Support for compression (based on [`rust-brotli`](https://github.com/dropbox/rust-brotli/))
 //! * Streamable archive creation:
 //!   * An archive can be built even over a data-diode

--- a/mlar/CHANGELOG.md
+++ b/mlar/CHANGELOG.md
@@ -10,8 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added/Changed since 1.3.0
 
 - MLA2 is now the default; it is **incompatible** with MLA1. MLA1 enters **low maintenance mode**
-- Hybrid classic/post-quantum encryption using **X25519 + ML-KEM1024**
-- Archive signing using hybrid classic/post-quantum signatures
+- Hybrid traditional/post-quantum encryption using **X25519 + ML-KEM1024**
+- Archive signing using hybrid traditional/post-quantum signatures
 - New archive format, enabling improved cryptographic and performance characteristics
 - Cryptographic layer reworked to **protect against truncation attacks**
 - Redesigned CLI for improved **simplicity, safety, and semver compatibility**
@@ -57,8 +57,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added/Changed
 
 - MLA2 is now the default; it is **incompatible** with MLA1. MLA1 enters **low maintenance mode**
-- Hybrid classic/post-quantum encryption using **X25519 + ML-KEM1024**
-- Archive signing using hybrid classic/post-quantum signatures
+- Hybrid traditional/post-quantum encryption using **X25519 + ML-KEM1024**
+- Archive signing using hybrid traditional/post-quantum signatures
 - Switched to **Rust 2024 edition**
 - New archive format, enabling improved cryptographic and performance characteristics
 - Cryptographic layer reworked to **protect against truncation attacks**


### PR DESCRIPTION
In English, traditional is the right way to talk about pre-quantum cryptography (cf. https://datatracker.ietf.org/doc/draft-connolly-cfrg-xwing-kem/ or https://datatracker.ietf.org/doc/html/draft-ietf-tls-hybrid-design)

This reverts commit b38988837275d911092bebdded0e5be5c9f0bd3e.

# PR summary

**What does this PR do?**
Revert doc crypto change

<!-- If this PR fixes an issue
**Related issues:**
Fixes #[issue-number]
-->

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Breaking change
- [x] Documentation

<!-- If applicable
## Screenshots / Context

_Add before/after screenshots, logs, or extra notes if helpful_
-->

<!--
Checklist:

- Read the [Contributing Guidelines](https://github.com/ANSSI-FR/MLA/blob/main/.github/CONTRIBUTING.md)
- Add tests for all changed behaviour.
- If you can't add a test, please explain why and how you verified your changes work.
- Make sure CI passes.
- Please do not force push to the PR once it has been reviewed.

-->
